### PR TITLE
Fix mysql.proc permission issue

### DIFF
--- a/stored_proc.sql.in
+++ b/stored_proc.sql.in
@@ -38,7 +38,7 @@ DELIMITER |
 CREATE PROCEDURE @TANGO_DB_NAME@.ds_start 
 (IN ds_name VARCHAR(255),
  IN recev_host VARCHAR(255),
- OUT res_str MEDIUMBLOB) READS SQL DATA COMMENT 'release 1.12'
+ OUT res_str MEDIUMBLOB) READS SQL DATA COMMENT 'release 1.13'
 proc: BEGIN
 
 	DECLARE notifd_event_name VARCHAR(255) DEFAULT 'notifd/factory/';

--- a/stored_proc.sql.in
+++ b/stored_proc.sql.in
@@ -981,10 +981,10 @@ BEGIN
 	DECLARE CONTINUE HANDLER FOR NOT FOUND SET not_found = 1;
 	DECLARE EXIT HANDLER FOR SQLEXCEPTION SET res_str = CONCAT_WS(CHAR(0),res_str,'MySQL Error');
 	
-	SELECT comment
+	SELECT ROUTINE_COMMENT
 	INTO tmp_rel
-	FROM mysql.proc 
-	WHERE name = 'ds_start' and Db = '@TANGO_DB_NAME@';
+	FROM INFORMATION_SCHEMA.ROUTINES
+	WHERE ROUTINE_NAME = 'ds_start' AND ROUTINE_SCHEMA = '@TANGO_DB_NAME@';
 	
 	IF not_found = 1 THEN
 		SET res_str = CONCAT_WS(CHAR(0),res_str,'Not Found');


### PR DESCRIPTION
SELECT privilege on mysql.proc is no longer necessary to avoid
"Unknown exception while trying to fill database cache..." error messages at
Tango 9 device servers startup when the database server is using a MySQL or MariaDB
account different from root.