### PR TITLE
Add DServer::EventConfirmSubscription command ...

### DIFF
--- a/create_db.sql.in
+++ b/create_db.sql.in
@@ -133,6 +133,7 @@ INSERT INTO property_class VALUES('DServer','AllowedAccessCmd',7,'QueryWizardDev
 INSERT INTO property_class VALUES('DServer','AllowedAccessCmd',8,'QueryWizardClassProperty',NOW(),NOW(),NULL);
 INSERT INTO property_class VALUES('DServer','AllowedAccessCmd',9,'QuerySubDevice',NOW(),NOW(),NULL);
 INSERT INTO property_class VALUES('DServer','AllowedAccessCmd',10,'ZMQEventSubscriptionChange',NOW(),NOW(),NULL);
+INSERT INTO property_class VALUES('DServer','AllowedAccessCmd',11,'EventConfirmSubscription',NOW(),NOW(),NULL);
 
 #
 #

--- a/update_db5.sql.in
+++ b/update_db5.sql.in
@@ -232,6 +232,7 @@ INSERT INTO property_class VALUES('DServer','AllowedAccessCmd',7,'QueryWizardDev
 INSERT INTO property_class VALUES('DServer','AllowedAccessCmd',8,'QueryWizardClassProperty',NULL,NULL,NULL);
 INSERT INTO property_class VALUES('DServer','AllowedAccessCmd',9,'QuerySubDevice',NULL,NULL,NULL);
 INSERT INTO property_class VALUES('DServer','AllowedAccessCmd',10,'ZMQEventSubscriptionChange',NULL,NULL,NULL);
+INSERT INTO property_class VALUES('DServer','AllowedAccessCmd',11,'EventConfirmSubscription',NULL,NULL,NULL);
 
 #
 #

--- a/update_db6.sql.in
+++ b/update_db6.sql.in
@@ -19,6 +19,7 @@ INSERT INTO property_class VALUES('Database','AllowedAccessCmd',34,'DbGetCSDbSer
 
 INSERT INTO property_class VALUES('DServer','AllowedAccessCmd',9,'QuerySubDevice',NULL,NULL,NULL);
 INSERT INTO property_class VALUES('DServer','AllowedAccessCmd',10,'ZMQEventSubscriptionChange',NULL,NULL,NULL);
+INSERT INTO property_class VALUES('DServer','AllowedAccessCmd',11,'EventConfirmSubscription',NULL,NULL,NULL);
 
 #
 #

--- a/update_db7.sql.in
+++ b/update_db7.sql.in
@@ -127,6 +127,7 @@ INSERT INTO property_class VALUES('Database','AllowedAccessCmd',45,'DbGetForward
 
 DELETE FROM property_class WHERE class='DServer' AND count >= 10;
 INSERT INTO property_class VALUES('DServer','AllowedAccessCmd',10,'ZMQEventSubscriptionChange',NOW(),NOW(),NULL);
+INSERT INTO property_class VALUES('DServer','AllowedAccessCmd',11,'EventConfirmSubscription',NOW(),NOW(),NULL);
 
 DELETE FROM property_class WHERE class='Starter' AND count >= 5;
 INSERT INTO property_class VALUES('Starter','AllowedAccessCmd',5,'UpdateServerList',NOW(),NOW(),NULL);

--- a/update_db8.sql.in
+++ b/update_db8.sql.in
@@ -105,7 +105,7 @@ ALTER TABLE device_history_id MODIFY id bigint unsigned NOT NULL default '0';
 ALTER TABLE object_history_id MODIFY id bigint unsigned NOT NULL default '0';
 
 #
-# Update entries in the property_class tables for database
+# Update entries in the property_class tables for controlled access service
 #
 
 DELETE FROM property_class WHERE class='Database' AND count >= 35;
@@ -121,6 +121,9 @@ INSERT INTO property_class VALUES('Database','AllowedAccessCmd',42,'DbGetClassPi
 INSERT INTO property_class VALUES('Database','AllowedAccessCmd',43,'DbGetDevicePipeList',NOW(),NOW(),NULL);
 INSERT INTO property_class VALUES('Database','AllowedAccessCmd',44,'DbGetAttributeAliasList',NOW(),NOW(),NULL);
 INSERT INTO property_class VALUES('Database','AllowedAccessCmd',45,'DbGetForwardedAttributeListForDevice',NOW(),NOW(),NULL);
+
+DELETE FROM property_class WHERE class='DServer' AND count >= 11;
+INSERT INTO property_class VALUES('DServer','AllowedAccessCmd',11,'EventConfirmSubscription',NOW(),NOW(),NULL);
 
 #
 # Remove history entries for the property used by memorized attribute


### PR DESCRIPTION
… to the default list of commands always allowed by TangoAccessControl

Thanks @egorbe for reporting this tango-controls/cppTango#507 issue and for proposing this improvement.