### PR TITLE
Fix compilation without "using namespace std"

### DIFF
--- a/DataBase.cpp
+++ b/DataBase.cpp
@@ -308,7 +308,7 @@ void DataBase::init_device()
 	const char *mysql_host = NULL;
 	const char *mysql_name = NULL;
 
-	WARN_STREAM << "DataBase::DataBase() create database device " << device_name << endl;
+	WARN_STREAM << "DataBase::DataBase() create database device " << device_name << std::endl;
 
 //
 // Check if we are using the thread safe release of the MySQL library
@@ -316,7 +316,7 @@ void DataBase::init_device()
 
 	if (mysql_thread_safe() == 0)
 	{
-		ERROR_STREAM << "MySQL library used by this process is not tread safe. Please, use libmysqlclient_r" << endl;
+		ERROR_STREAM << "MySQL library used by this process is not tread safe. Please, use libmysqlclient_r" << std::endl;
 
 		Tango::Except::throw_exception((const char *)DB_MySQLLibNotThreadSafe,
 	   				  (const char *)"MySQL library used by this process is not thread safe. Please, use libmysqlclient_r or use DataBase release < 4.x",
@@ -391,7 +391,7 @@ void DataBase::init_device()
 		fireToStarter = true;
 	}
 
-	WARN_STREAM << "fireToStarter = " << fireToStarter << endl;
+	WARN_STREAM << "fireToStarter = " << fireToStarter << std::endl;
 
 	//	If fire to starter is true
 	if (fireToStarter==true)
@@ -418,7 +418,7 @@ void DataBase::init_device()
                 }
             }
         }
-        //cout << "-----------> Starter domain = " << starter_domain << endl;
+        //cout << "-----------> Starter domain = " << starter_domain << std::endl;
 
     	delete array;
 	    delete props;
@@ -449,7 +449,7 @@ void DataBase::init_device()
 		    ss >> historyDepth;
 
 		    if( historyDepth == 0 ) {
-		      cout << "Warning, Invalid historyDepth property, resetting to default value (10)" << endl;
+		      cout << "Warning, Invalid historyDepth property, resetting to default value (10)" << std::endl;
 		      historyDepth = 10;
 		    }
 		  }
@@ -528,12 +528,12 @@ void DataBase::read_StoredProcedureRelease(Tango::Attribute &attr)
 	sql_query_stream << mysql_db_name;
 	sql_query_stream << "\" AND Name LIKE \"ds_start\"";
 
-	DEBUG_STREAM << "DataBase::read_StoredProcedureRelease(): sql_query " << sql_query_stream.str() << endl;
+	DEBUG_STREAM << "DataBase::read_StoredProcedureRelease(): sql_query " << sql_query_stream.str() << std::endl;
 
 	result = query(sql_query_stream.str(),"read_StoredProcedureRelease()");
 
 	n_fields = mysql_num_fields(result);
-	DEBUG_STREAM << "DataBase::read_StoreProcedureRelease(): mysql_num_fields() " << n_fields << endl;
+	DEBUG_STREAM << "DataBase::read_StoreProcedureRelease(): mysql_num_fields() " << n_fields << std::endl;
 
 	if (n_fields > 7)
 	{
@@ -815,13 +815,13 @@ void DataBase::db_add_device(const Tango::DevVarStringArray *argin)
 
 	if (server_device->length() < 3)
 	{
-	   WARN_STREAM << "DataBase::AddDevice(): incorrect number of input arguments " << endl;
+	   WARN_STREAM << "DataBase::AddDevice(): incorrect number of input arguments " << std::endl;
 	   Tango::Except::throw_exception((const char *)DB_IncorrectArguments,
 	   				  (const char *)"incorrect no. of input arguments, needs at least 3 (server,device,class)",
 					  (const char *)"DataBase::AddDevice()");
 	}
 
-	INFO_STREAM << "DataBase::AddDevice(): insert " << (*server_device)[0] << " server with device " << (*server_device)[1] << endl;
+	INFO_STREAM << "DataBase::AddDevice(): insert " << (*server_device)[0] << " server with device " << (*server_device)[1] << std::endl;
 	tmp_server = (*server_device)[0];
 	tmp_device = (*server_device)[1];
 	tmp_class = (*server_device)[2];
@@ -846,7 +846,7 @@ void DataBase::db_add_device(const Tango::DevVarStringArray *argin)
 // first delete the tuple (device,name) from the device table
 
 		sql_query_stream << "DELETE FROM device WHERE name LIKE \"" << tmp_device << "\"";
-		DEBUG_STREAM << "DataBase::AddDevice(): sql_query " << sql_query_stream.str() << endl;
+		DEBUG_STREAM << "DataBase::AddDevice(): sql_query " << sql_query_stream.str() << std::endl;
 		simple_query(sql_query_stream.str(),"db_add_device()",al.get_con_nb());
 
 // then insert the new value for this tuple
@@ -871,7 +871,7 @@ void DataBase::db_add_device(const Tango::DevVarStringArray *argin)
 							 << "\",alias=\"" << tmp_alias
 							 << "\",version=\"0\",started=NULL,stopped=NULL";
 		}
-		DEBUG_STREAM << "DataBase::AddDevice(): sql_query " << sql_query_stream.str() << endl;
+		DEBUG_STREAM << "DataBase::AddDevice(): sql_query " << sql_query_stream.str() << std::endl;
 		simple_query(sql_query_stream.str(),"db_add_device()",al.get_con_nb());
 
 //
@@ -880,11 +880,11 @@ void DataBase::db_add_device(const Tango::DevVarStringArray *argin)
     	sql_query_stream.str("");
 		sql_query_stream << "SELECT name FROM device WHERE server LIKE \"" << tmp_server
 	                	 << "\" AND class LIKE \"DServer\"";
-		DEBUG_STREAM << "DataBase::AddDevice(): sql_query " << sql_query_stream.str() << endl;
+		DEBUG_STREAM << "DataBase::AddDevice(): sql_query " << sql_query_stream.str() << std::endl;
 		result = query(sql_query_stream.str(),"db_add_device()",al.get_con_nb());
 
 		n_rows = mysql_num_rows(result);
-		DEBUG_STREAM << "DataBase::AddDevice(): mysql_num_rows() " << n_rows << endl;
+		DEBUG_STREAM << "DataBase::AddDevice(): mysql_num_rows() " << n_rows << std::endl;
 
 //
 // If there is no admin device for the device's server, create one
@@ -901,7 +901,7 @@ void DataBase::db_add_device(const Tango::DevVarStringArray *argin)
 							 << "\",member=\"" << member
 							 << "\",exported=0,ior=\"nada\",host=\"nada\",server=\"" << tmp_server
 							 << "\",pid=0,class=\"DServer\",version=\"0\",started=NULL,stopped=NULL";
-			DEBUG_STREAM << "DataBase::AddDevice(): sql_query " << sql_query_stream.str() << endl;
+			DEBUG_STREAM << "DataBase::AddDevice(): sql_query " << sql_query_stream.str() << std::endl;
   	    	simple_query(sql_query_stream.str(),"db_add_device()",al.get_con_nb());
 
 		}
@@ -938,13 +938,13 @@ void DataBase::db_add_server(const Tango::DevVarStringArray *argin)
 
 	if (server_device_list->length() < 3)
 	{
-	   WARN_STREAM << "DataBase::AddServer(): incorrect number of input arguments " << endl;
+	   WARN_STREAM << "DataBase::AddServer(): incorrect number of input arguments " << std::endl;
 	   Tango::Except::throw_exception((const char *)DB_IncorrectArguments,
 	   				  (const char *)"incorrect no. of input arguments, needs at least 3 (server,device,class)",
 					  (const char *)"DataBase::AddServer()");
 	}
 
-	INFO_STREAM << "DataBase::AddServer(): insert " << (*server_device_list)[0] << " server with device " << (*server_device_list)[1] << endl;
+	INFO_STREAM << "DataBase::AddServer(): insert " << (*server_device_list)[0] << " server with device " << (*server_device_list)[1] << std::endl;
 	tmp_server = (*server_device_list)[0];
 
 	{
@@ -969,7 +969,7 @@ void DataBase::db_add_server(const Tango::DevVarStringArray *argin)
         	sql_query_stream.str("");
         	sql_query_stream << "DELETE FROM device WHERE server=\"" << tmp_server
 		                	 << "\" AND name=\"" << tmp_device << "\" ";
-			DEBUG_STREAM << "DataBase::AddServer(): sql_query " << sql_query_stream.str() << endl;
+			DEBUG_STREAM << "DataBase::AddServer(): sql_query " << sql_query_stream.str() << std::endl;
 			simple_query(sql_query_stream.str(),"db_add_server()",al.get_con_nb());
 
 // then insert the new value for this tuple
@@ -981,7 +981,7 @@ void DataBase::db_add_server(const Tango::DevVarStringArray *argin)
 							 << "\",exported=0,ior=\"nada\",host=\"nada\",server=\"" << tmp_server
 							 << "\",pid=0,class=\"" << tmp_class
 							 << "\",version=0,started=NULL,stopped=NULL";
-			DEBUG_STREAM << "DataBase::AddServer(): sql_query " << sql_query_stream.str() << endl;
+			DEBUG_STREAM << "DataBase::AddServer(): sql_query " << sql_query_stream.str() << std::endl;
 			simple_query(sql_query_stream.str(),"db_add_server()",al.get_con_nb());
 
 		}
@@ -996,7 +996,7 @@ void DataBase::db_add_server(const Tango::DevVarStringArray *argin)
         sql_query_stream.str("");
         sql_query_stream << "DELETE FROM device WHERE server=\"" << tmp_server
 		                	 << "\" AND name=\"" << tmp_device << "\" ";
-        DEBUG_STREAM << "DataBase::AddServer(): sql_query " << sql_query_stream.str() << endl;
+        DEBUG_STREAM << "DataBase::AddServer(): sql_query " << sql_query_stream.str() << std::endl;
         simple_query(sql_query_stream.str(),"db_add_server()",al.get_con_nb());
 
         tmp_class = "DServer";
@@ -1007,7 +1007,7 @@ void DataBase::db_add_server(const Tango::DevVarStringArray *argin)
 							 << "\",exported=0,ior=\"nada\",host=\"nada\",server=\"" << tmp_server
 							 << "\",pid=0,class=\"" << tmp_class
 							 << "\",version=0,started=NULL,stopped=NULL";
-        DEBUG_STREAM << "DataBase::AddServer(): sql_query " << sql_query_stream.str() << endl;
+        DEBUG_STREAM << "DataBase::AddServer(): sql_query " << sql_query_stream.str() << std::endl;
         simple_query(sql_query_stream.str(),"db_add_server()",al.get_con_nb());
 	}
 
@@ -1033,7 +1033,7 @@ void DataBase::db_delete_attribute_alias(Tango::DevString argin)
 
 	// first check to see if this alias exists
 	sql_query_stream << "DELETE  FROM attribute_alias WHERE alias=\'" << argin << "\' ";
-	DEBUG_STREAM << "DataBase::db_delete_attribute_alias(): sql_query " << sql_query_stream.str() << endl;
+	DEBUG_STREAM << "DataBase::db_delete_attribute_alias(): sql_query " << sql_query_stream.str() << std::endl;
 	simple_query(sql_query_stream.str(),"db_delete_attribute_alias()");
 
 	/*----- PROTECTED REGION END -----*/	//	DataBase::db_delete_attribute_alias
@@ -1059,7 +1059,7 @@ void DataBase::db_delete_class_attribute(const Tango::DevVarStringArray *argin)
 
 	if (argin->length() < 2) {
    		WARN_STREAM << "DataBase::db_delete_class_attribute(): insufficient number of arguments ";
-   		WARN_STREAM << endl;
+   		WARN_STREAM << std::endl;
    		Tango::Except::throw_exception((const char *)DB_IncorrectArguments,
 					       (const char *)"insufficient number of arguments to delete class attribute",
 					       (const char *)"DataBase::db_delete_class_attribute()");
@@ -1068,13 +1068,13 @@ void DataBase::db_delete_class_attribute(const Tango::DevVarStringArray *argin)
 	tmp_class = (*argin)[0];
 	attribute = (*argin)[1];
 
-	INFO_STREAM << "DataBase::db_delete_class_attribute(): delete " << tmp_class << " from database" << endl;
+	INFO_STREAM << "DataBase::db_delete_class_attribute(): delete " << tmp_class << " from database" << std::endl;
 
 // then delete class from the property_attribute_class table
 
     sql_query_stream << "DELETE FROM property_attribute_class WHERE class LIKE \"" << tmp_class
 	                 << "\" AND attribute LIKE \"" << attribute << "\" ";
-    DEBUG_STREAM << "DataBase::db_delete_class_attribute(): sql_query " << sql_query_stream.str() << endl;
+    DEBUG_STREAM << "DataBase::db_delete_class_attribute(): sql_query " << sql_query_stream.str() << std::endl;
 	simple_query(sql_query_stream.str(),"db_delete_class_attribute()");
 
     return;
@@ -1106,7 +1106,7 @@ void DataBase::db_delete_class_attribute_property(const Tango::DevVarStringArray
 
 	if (argin->length() < 3) {
    		WARN_STREAM << "DataBase::db_delete_class_attribute_property(): insufficient number of arguments ";
-   		WARN_STREAM << endl;
+   		WARN_STREAM << std::endl;
    		Tango::Except::throw_exception((const char *)DB_IncorrectArguments,
 					       (const char *)"insufficient number of arguments to delete class attribute property",
 					       (const char *)"DataBase::db_delete_class_attribute_property()");
@@ -1123,7 +1123,7 @@ void DataBase::db_delete_class_attribute_property(const Tango::DevVarStringArray
 			property = (*argin)[i+2];
 
 			INFO_STREAM << "DataBase::db_delete_class_attribute_property(): delete class " << tmp_class ;
-			INFO_STREAM << " attribute " << attribute << " property[" << i <<"] " << property << " from database" << endl;
+			INFO_STREAM << " attribute " << attribute << " property[" << i <<"] " << property << " from database" << std::endl;
 
 // Is there something to delete ?
 
@@ -1131,7 +1131,7 @@ void DataBase::db_delete_class_attribute_property(const Tango::DevVarStringArray
 			sql_query_stream << "SELECT count(*) FROM property_attribute_class WHERE class = \"" << tmp_class
 		                	 << "\" AND attribute = \"" << attribute << "\" AND name = \"" << property
 							 << "\" ";
-   			DEBUG_STREAM << "DataBase::db_delete_class_attribute_property(): sql_query " << sql_query_stream.str() << endl;
+   			DEBUG_STREAM << "DataBase::db_delete_class_attribute_property(): sql_query " << sql_query_stream.str() << std::endl;
 			result = query(sql_query_stream.str(),"db_delete_class_attribute_property()",al.get_con_nb());
  	    	row = mysql_fetch_row(result);
 			int count;
@@ -1148,7 +1148,7 @@ void DataBase::db_delete_class_attribute_property(const Tango::DevVarStringArray
 			  sql_query_stream << "DELETE FROM property_attribute_class WHERE class = \"" << tmp_class
 		                	   << "\" AND attribute = \"" << attribute << "\" AND name = \"" << property
 							   << "\" ";
-   			  DEBUG_STREAM << "DataBase::db_delete_class_attribute_property(): sql_query " << sql_query_stream.str() << endl;
+   			  DEBUG_STREAM << "DataBase::db_delete_class_attribute_property(): sql_query " << sql_query_stream.str() << std::endl;
 			  simple_query(sql_query_stream.str(),"db_delete_class_attribute_property()",al.get_con_nb());
 
 // Mark this property as deleted
@@ -1160,7 +1160,7 @@ void DataBase::db_delete_class_attribute_property(const Tango::DevVarStringArray
 													 << "',name='" << property \
 													 << "',id='" << class_attribute_property_hist_id \
 													 << "',count='0',value='DELETED'";
-	    	  DEBUG_STREAM << "DataBase::db_delete_class_attribute_property(): sql_query " << sql_query_stream.str() << endl;
+	    	  DEBUG_STREAM << "DataBase::db_delete_class_attribute_property(): sql_query " << sql_query_stream.str() << std::endl;
 			  simple_query(sql_query_stream.str(),"db_delete_class_attribute_property()",al.get_con_nb());
 
 			}
@@ -1197,7 +1197,7 @@ void DataBase::db_delete_class_property(const Tango::DevVarStringArray *argin)
 	MYSQL_ROW row;
 
 	n_properties = property_list->length() - 1;
-	INFO_STREAM << "DataBase::DeleteClassProperty(): delete " << n_properties << " properties for class " << (*property_list)[0] << endl;
+	INFO_STREAM << "DataBase::DeleteClassProperty(): delete " << n_properties << " properties for class " << (*property_list)[0] << std::endl;
 
 	{
 		AutoLock al("LOCK TABLES property_class WRITE,property_class_hist WRITE,class_history_id WRITE",this);
@@ -1224,7 +1224,7 @@ void DataBase::db_delete_class_property(const Tango::DevVarStringArray *argin)
 		    	sql_query_stream.str("");
 		    	sql_query_stream << "DELETE FROM property_class WHERE class=\"" << tmp_class
 		                	   << "\" AND name=\"" << row[0] << "\"";
-	        	DEBUG_STREAM << "DataBase::DeleteClassProperty(): sql_query " << sql_query_stream.str() << endl;
+	        	DEBUG_STREAM << "DataBase::DeleteClassProperty(): sql_query " << sql_query_stream.str() << std::endl;
 		    	simple_query(sql_query_stream.str(),"db_delete_class_property()",al.get_con_nb());
 
 				// Mark this property as deleted
@@ -1234,7 +1234,7 @@ void DataBase::db_delete_class_property(const Tango::DevVarStringArray *argin)
 													 << "',name='" << row[0] \
 													 << "',id='" << class_property_hist_id \
 													 << "',count='0',value='DELETED'";
-	        	DEBUG_STREAM << "DataBase::PutClassProperty(): sql_query " << sql_query_stream.str() << endl;
+	        	DEBUG_STREAM << "DataBase::PutClassProperty(): sql_query " << sql_query_stream.str() << std::endl;
   	        	simple_query(sql_query_stream.str(),"db_delete_class_property()",al.get_con_nb());
 
    	        	purge_property("property_class_hist","class",tmp_class,row[0],al.get_con_nb());
@@ -1267,7 +1267,7 @@ void DataBase::db_delete_device(Tango::DevString argin)
 	TangoSys_MemStream sql_query_stream;
 	string tmp_device;
 
-	INFO_STREAM << "DataBase::db_delete_device(): delete " << device << " from database" << endl;
+	INFO_STREAM << "DataBase::db_delete_device(): delete " << device << " from database" << std::endl;
 
 // first check the device name
 
@@ -1275,7 +1275,7 @@ void DataBase::db_delete_device(Tango::DevString argin)
 	if (!check_device_name(tmp_device))
 	{
          	WARN_STREAM << "DataBase::db_delete_device(): device name  " << device << " incorrect ";
-         	WARN_STREAM << endl;
+         	WARN_STREAM << std::endl;
          	Tango::Except::throw_exception((const char *)DB_IncorrectDeviceName,
 					       (const char *)"failed to delete device, device name incorrect",
 					       (const char *)"DataBase::db_delete_device()");
@@ -1291,35 +1291,35 @@ void DataBase::db_delete_device(Tango::DevString argin)
 // then delete the device from the device table
 
     	sql_query_stream << "DELETE FROM device WHERE name LIKE \"" << tmp_wildcard << "\"";
-    	DEBUG_STREAM << "DataBase::db_delete_device(): sql_query " << sql_query_stream.str() << endl;
+    	DEBUG_STREAM << "DataBase::db_delete_device(): sql_query " << sql_query_stream.str() << std::endl;
 		simple_query(sql_query_stream.str(),"db_delete_device()",al.get_con_nb());
 
 // then delete device from the property_device table
 
     	sql_query_stream.str("");
 		sql_query_stream << "DELETE FROM property_device WHERE device LIKE \"" << tmp_wildcard << "\"";
-    	DEBUG_STREAM << "DataBase::db_delete_device(): sql_query " << sql_query_stream.str() << endl;
+    	DEBUG_STREAM << "DataBase::db_delete_device(): sql_query " << sql_query_stream.str() << std::endl;
 		simple_query(sql_query_stream.str(),"db_delete_device()",al.get_con_nb());
 
 // then delete device from the property_attribute_device table
 
     	sql_query_stream.str("");
 		sql_query_stream << "DELETE FROM property_attribute_device WHERE device LIKE \"" << tmp_wildcard << "\"";
-    	DEBUG_STREAM << "DataBase::db_delete_device(): sql_query " << sql_query_stream.str() << endl;
+    	DEBUG_STREAM << "DataBase::db_delete_device(): sql_query " << sql_query_stream.str() << std::endl;
 		simple_query(sql_query_stream.str(),"db_delete_device()",al.get_con_nb());
 
 // then delete device from the property_pipe_device table
 
     	sql_query_stream.str("");
 		sql_query_stream << "DELETE FROM property_pipe_device WHERE device LIKE \"" << tmp_wildcard << "\"";
-    	DEBUG_STREAM << "DataBase::db_delete_device(): sql_query " << sql_query_stream.str() << endl;
+    	DEBUG_STREAM << "DataBase::db_delete_device(): sql_query " << sql_query_stream.str() << std::endl;
 		simple_query(sql_query_stream.str(),"db_delete_device()",al.get_con_nb());
 
 // then delete device from attribute_alias table
 
 		sql_query_stream.str("");
 		sql_query_stream << "DELETE FROM attribute_alias WHERE device LIKE \"" << tmp_wildcard << "\"";
-		DEBUG_STREAM << "DataBase::db_delete_device(): sql_query " << sql_query_stream.str() << endl;
+		DEBUG_STREAM << "DataBase::db_delete_device(): sql_query " << sql_query_stream.str() << std::endl;
 		simple_query(sql_query_stream.str(),"db_delete_device()",al.get_con_nb());
 	}
 
@@ -1345,7 +1345,7 @@ void DataBase::db_delete_device_alias(Tango::DevString argin)
 
 	// first check to see if this alias exists
 	sql_query_stream << "UPDATE device SET alias=null WHERE alias=\'" << argin << "\' ";
-	DEBUG_STREAM  << "DataBase::db_delete_device_alias(): sql_query " << sql_query_stream.str() << endl;
+	DEBUG_STREAM  << "DataBase::db_delete_device_alias(): sql_query " << sql_query_stream.str() << std::endl;
 	simple_query(sql_query_stream.str(),"db_delete_device_alias()");
 
 	/*----- PROTECTED REGION END -----*/	//	DataBase::db_delete_device_alias
@@ -1371,7 +1371,7 @@ void DataBase::db_delete_device_attribute(const Tango::DevVarStringArray *argin)
 
 	if (argin->length() < 2) {
    		WARN_STREAM << "DataBase::db_delete_device_attribute(): insufficient number of arguments ";
-   		WARN_STREAM << endl;
+   		WARN_STREAM << std::endl;
    		Tango::Except::throw_exception((const char *)DB_IncorrectArguments,
 					       (const char *)"insufficient number of arguments to delete device attribute",
 					       (const char *)"DataBase::db_delete_device_attribute()");
@@ -1380,14 +1380,14 @@ void DataBase::db_delete_device_attribute(const Tango::DevVarStringArray *argin)
 	tmp_device = (*argin)[0].in();
 	attribute = (*argin)[1];
 
-	INFO_STREAM << "DataBase::db_delete_device(): delete " << tmp_device << " from database" << endl;
+	INFO_STREAM << "DataBase::db_delete_device(): delete " << tmp_device << " from database" << std::endl;
 
 // first check the device name
 
 	if (!check_device_name(tmp_device))
 	{
          	WARN_STREAM << "DataBase::db_delete_device_attribute(): device name  " << tmp_device << " incorrect ";
-         	WARN_STREAM << endl;
+         	WARN_STREAM << std::endl;
          	Tango::Except::throw_exception((const char *)DB_IncorrectDeviceName,
 					       (const char *)"failed to delete device attribute, device name incorrect",
 					       (const char *)"DataBase::db_delete_device_attribute()");
@@ -1401,7 +1401,7 @@ void DataBase::db_delete_device_attribute(const Tango::DevVarStringArray *argin)
 
     sql_query_stream << "DELETE FROM property_attribute_device WHERE device LIKE \""
 	                 << tmp_wildcard << "\" AND attribute LIKE \"" << attribute << "\" ";
-    DEBUG_STREAM << "DataBase::db_delete_device_attribute(): sql_query " << sql_query_stream.str() << endl;
+    DEBUG_STREAM << "DataBase::db_delete_device_attribute(): sql_query " << sql_query_stream.str() << std::endl;
 	simple_query(sql_query_stream.str(),"db_delete_device_attribute()");
 
     return;
@@ -1433,7 +1433,7 @@ void DataBase::db_delete_device_attribute_property(const Tango::DevVarStringArra
 
 	if (argin->length() < 3) {
    		WARN_STREAM << "DataBase::db_delete_device_attribute_property(): insufficient number of arguments ";
-   		WARN_STREAM << endl;
+   		WARN_STREAM << std::endl;
    		Tango::Except::throw_exception((const char *)DB_IncorrectArguments,
 					       (const char *)"insufficient number of arguments to delete device attribute property",
 					       (const char *)"DataBase::db_delete_device_attribute_property()");
@@ -1443,7 +1443,7 @@ void DataBase::db_delete_device_attribute_property(const Tango::DevVarStringArra
 	if (!check_device_name(tmp_device))
 	{
         	WARN_STREAM << "DataBase::db_delete_device_attribute(): device name  " << tmp_device << " incorrect ";
-         	WARN_STREAM << endl;
+         	WARN_STREAM << std::endl;
          	Tango::Except::throw_exception((const char *)DB_IncorrectDeviceName,
 				       	(const char *)"failed to delete device attribute, device name incorrect",
 				       	(const char *)"DataBase::db_delete_device_attribute()");
@@ -1459,7 +1459,7 @@ void DataBase::db_delete_device_attribute_property(const Tango::DevVarStringArra
 			property = (*argin)[i+2];
 
 			INFO_STREAM << "DataBase::db_delete_device_attribute_property(): delete device " << tmp_device ;
-			INFO_STREAM << " attribute " << attribute << " property[" << i <<"] " << property << " from database" << endl;
+			INFO_STREAM << " attribute " << attribute << " property[" << i <<"] " << property << " from database" << std::endl;
 
 // Is there something to delete ?
 
@@ -1481,7 +1481,7 @@ void DataBase::db_delete_device_attribute_property(const Tango::DevVarStringArra
 			  sql_query_stream.str("");
 			  sql_query_stream << "DELETE FROM property_attribute_device WHERE device = \"" << tmp_device
 		                	   <<"\" AND attribute = \"" << attribute << "\" AND name = \"" << property << "\" ";
-   			  DEBUG_STREAM << "DataBase::db_delete_device_attribute_property(): sql_query " << sql_query_stream.str() << endl;
+   			  DEBUG_STREAM << "DataBase::db_delete_device_attribute_property(): sql_query " << sql_query_stream.str() << std::endl;
 			  simple_query(sql_query_stream.str(),"db_delete_device_attribute_property()",al.get_con_nb());
 
 // Mark this property as deleted
@@ -1493,7 +1493,7 @@ void DataBase::db_delete_device_attribute_property(const Tango::DevVarStringArra
 							   << "',name='" << property
 							   << "',id='" << device_attribute_property_hist_id
 							   << "',count='0',value='DELETED'";
-	    	  DEBUG_STREAM << "DataBase::PutAttributeProperty(): sql_query " << sql_query_stream.str() << endl;
+	    	  DEBUG_STREAM << "DataBase::PutAttributeProperty(): sql_query " << sql_query_stream.str() << std::endl;
 			  simple_query(sql_query_stream.str(),"db_delete_device_attribute_property()",al.get_con_nb());
 
 			}
@@ -1533,7 +1533,7 @@ void DataBase::db_delete_device_property(const Tango::DevVarStringArray *argin)
 	GetTime(before);
 
 	n_properties = property_list->length() - 1;
-	INFO_STREAM << "DataBase::DeleteDeviceProperty(): delete " << n_properties << " properties for device " << (*property_list)[0] << endl;
+	INFO_STREAM << "DataBase::DeleteDeviceProperty(): delete " << n_properties << " properties for device " << (*property_list)[0] << std::endl;
 
 	{
 		AutoLock al("LOCK TABLES property_device WRITE, property_device_hist WRITE,device_history_id WRITE",this);
@@ -1561,7 +1561,7 @@ void DataBase::db_delete_device_property(const Tango::DevVarStringArray *argin)
             	sql_query_stream.str("");
 	        	sql_query_stream << "DELETE FROM property_device WHERE device=\""
 		                    	 << tmp_device << "\" AND name=\"" << row[0] << "\"";
-	        	DEBUG_STREAM << "DataBase::DeleteDeviceProperty(): sql_query " << sql_query_stream.str() << endl;
+	        	DEBUG_STREAM << "DataBase::DeleteDeviceProperty(): sql_query " << sql_query_stream.str() << std::endl;
 		    	simple_query(sql_query_stream.str(),"db_delete_device_property()",al.get_con_nb());
 
 				// Mark this property as deleted
@@ -1613,7 +1613,7 @@ void DataBase::db_delete_property(const Tango::DevVarStringArray *argin)
 	MYSQL_ROW row;
 
 	n_properties = property_list->length() - 1;
-	INFO_STREAM << "DataBase::db_delete_property(): put " << n_properties << " properties for device " << (*property_list)[0] << endl;
+	INFO_STREAM << "DataBase::db_delete_property(): put " << n_properties << " properties for device " << (*property_list)[0] << std::endl;
 
 	{
 		AutoLock al("LOCK TABLES property WRITE, property_hist WRITE,object_history_id WRITE",this);
@@ -1641,7 +1641,7 @@ void DataBase::db_delete_property(const Tango::DevVarStringArray *argin)
 		    	sql_query_stream.str("");
 		    	sql_query_stream << "DELETE FROM property WHERE object=\"" << tmp_object
 		                	   << "\" AND name = \"" << row[0] << "\"";
-	        	DEBUG_STREAM << "DataBase::db_delete_property(): sql_query " << sql_query_stream.str() << endl;
+	        	DEBUG_STREAM << "DataBase::db_delete_property(): sql_query " << sql_query_stream.str() << std::endl;
 		    	simple_query(sql_query_stream.str(),"db_delete_property()",al.get_con_nb());
 
 				// Mark this property as deleted
@@ -1652,7 +1652,7 @@ void DataBase::db_delete_property(const Tango::DevVarStringArray *argin)
 											 << "',name='" << row[0]
 											 << "',id='" << object_property_hist_id
 											 << "',count='0',value='DELETED'";
-	        	DEBUG_STREAM << "DataBase::db_put_property(): sql_query " << sql_query_stream.str() << endl;
+	        	DEBUG_STREAM << "DataBase::db_put_property(): sql_query " << sql_query_stream.str() << std::endl;
 		    	simple_query(sql_query_stream.str(),"db_delete_property()",al.get_con_nb());
 
             	purge_property("property_hist","object",tmp_object,row[0],al.get_con_nb());
@@ -1688,7 +1688,7 @@ void DataBase::db_delete_server(Tango::DevString argin)
 	MYSQL_ROW row;
 	int n_rows;
 
-	INFO_STREAM << "DataBase::db_delete_server(): delete server " << server << " from database" << endl;
+	INFO_STREAM << "DataBase::db_delete_server(): delete server " << server << " from database" << std::endl;
 
 // first check the server name that it has no wildcard '*' and
 // that it has at least one slash in it
@@ -1700,7 +1700,7 @@ void DataBase::db_delete_server(Tango::DevString argin)
 	    (tmp_server.find('/') == string::npos))
 	{
          	WARN_STREAM << "DataBase::db_delete_server(): server name  " << server << "incorrect ";
-         	WARN_STREAM << endl;
+         	WARN_STREAM << std::endl;
          	Tango::Except::throw_exception((const char *)DB_IncorrectServerName,
 					       (const char *)"failed to delete server, server name incorrect",
 					       (const char *)"DataBase::db_delete_server()");
@@ -1723,7 +1723,7 @@ void DataBase::db_delete_server(Tango::DevString argin)
 		{
 			char *tmp_ptr = db_get_device_host((Tango::DevString)adm_dev.c_str());
 			previous_host = tmp_ptr;
-			DEBUG_STREAM << tmp_server << " was running on " << previous_host << endl;
+			DEBUG_STREAM << tmp_server << " was running on " << previous_host << std::endl;
 			CORBA::string_free(tmp_ptr);
 		}
 		catch (Tango::DevFailed &e)
@@ -1731,7 +1731,7 @@ void DataBase::db_delete_server(Tango::DevString argin)
 			string reason(e.errors[0].reason.in());
 			if (reason == DB_DeviceNotDefined)
 			{
-				WARN_STREAM << "DataBase::db_delete_server(): server " << tmp_server << " not defined in DB" << endl;
+				WARN_STREAM << "DataBase::db_delete_server(): server " << tmp_server << " not defined in DB" << std::endl;
 				TangoSys_OMemStream o;
 				o << "Server " << tmp_server << " not defined in database !";
 				Tango::Except::throw_exception((const char *)DB_IncorrectServerName,o.str(),
@@ -1746,12 +1746,12 @@ void DataBase::db_delete_server(Tango::DevString argin)
 //
 
 	sql_query_stream << "SELECT name FROM device WHERE server LIKE \"" << tmp_server << "\" ORDER BY name";
-	DEBUG_STREAM << "DataBase::db_delete_server_info(): sql_query " << sql_query_stream.str() << endl;
+	DEBUG_STREAM << "DataBase::db_delete_server_info(): sql_query " << sql_query_stream.str() << std::endl;
 
 	result = query(sql_query_stream.str(),"db_delete_server()");
 
 	n_rows = mysql_num_rows(result);
-	DEBUG_STREAM << "DataBase::db_delete_server(): mysql_num_rows() " << n_rows << endl;
+	DEBUG_STREAM << "DataBase::db_delete_server(): mysql_num_rows() " << n_rows << std::endl;
 
 //
 // Delete device(s) and associated properties
@@ -1763,7 +1763,7 @@ void DataBase::db_delete_server(Tango::DevString argin)
 		{
 			if ((row = mysql_fetch_row(result)) != NULL)
 			{
-				DEBUG_STREAM << "Database::db_deleet_server(): Deleting device " << row[0] << endl;
+				DEBUG_STREAM << "Database::db_deleet_server(): Deleting device " << row[0] << std::endl;
 				db_delete_device(row[0]);
 			}
 		}
@@ -1805,7 +1805,7 @@ void DataBase::db_delete_server_info(Tango::DevString argin)
 	Tango::DevString  server_name = argin;
 	TangoSys_MemStream sql_query_stream;
 
-	INFO_STREAM << "DataBase::db_delete_server_info(): delete " << server_name << " from database" << endl;
+	INFO_STREAM << "DataBase::db_delete_server_info(): delete " << server_name << " from database" << std::endl;
 
 // replace database wildcards (% and _)
 
@@ -1813,7 +1813,7 @@ void DataBase::db_delete_server_info(Tango::DevString argin)
 
 // then delete the device from the device table
     sql_query_stream << "DELETE FROM server WHERE name = \"" << server_name << "\"";
-    DEBUG_STREAM << "DataBase::db_delete_server_info(): sql_query " << sql_query_stream.str() << endl;
+    DEBUG_STREAM << "DataBase::db_delete_server_info(): sql_query " << sql_query_stream.str() << std::endl;
 	simple_query(sql_query_stream.str(),"db_delete_server_info()");
 
 	/*----- PROTECTED REGION END -----*/	//	DataBase::db_delete_server_info
@@ -1849,13 +1849,13 @@ void DataBase::db_export_device(const Tango::DevVarStringArray *argin)
 
 	if (export_info->length() < 5) {
    		WARN_STREAM << "DataBase::DbExportDevice(): insufficient export info for device ";
-   		WARN_STREAM << tmp_device << endl;
+   		WARN_STREAM << tmp_device << std::endl;
    		Tango::Except::throw_exception((const char *)DB_IncorrectArguments,
 					       (const char *)"Insufficient export info for device",
 					       (const char *)"DataBase::DbExportDevice()");
 	}
 
-	INFO_STREAM << "DataBase::ExportDevice(): put " << export_info->length()-1 << " export info for device " << (*export_info)[0] << endl;
+	INFO_STREAM << "DataBase::ExportDevice(): put " << export_info->length()-1 << " export info for device " << (*export_info)[0] << std::endl;
 
 	tmp_device = (*export_info)[0];
 	for (unsigned  int i=0; i<tmp_device.length(); i++) {
@@ -1896,7 +1896,7 @@ void DataBase::db_export_device(const Tango::DevVarStringArray *argin)
 					do_fire = true;
 					char *tmp_ptr = db_get_device_host((Tango::DevString)tmp_device.c_str(),al.get_con_nb());
 					previous_host = tmp_ptr;
-					DEBUG_STREAM << tmp_device << " was running on " << previous_host << endl;
+					DEBUG_STREAM << tmp_device << " was running on " << previous_host << std::endl;
 					CORBA::string_free(tmp_ptr);
 				}
 			}
@@ -1907,25 +1907,25 @@ void DataBase::db_export_device(const Tango::DevVarStringArray *argin)
 // update server table
 //
 		sql_query_stream << "SELECT server FROM device WHERE name LIKE \"" << tmp_device << "\" ";
-		DEBUG_STREAM << "DataBase::ExportDevice(): sql_query " << sql_query_stream.str() << endl;
+		DEBUG_STREAM << "DataBase::ExportDevice(): sql_query " << sql_query_stream.str() << std::endl;
 
 		result = query(sql_query_stream.str(),"db_export_device()",al.get_con_nb());
 
 		long n_rows=0;
 		n_rows = mysql_num_rows(result);
-		DEBUG_STREAM << "DataBase::ExportDevice(): mysql_num_rows() " << n_rows << endl;
+		DEBUG_STREAM << "DataBase::ExportDevice(): mysql_num_rows() " << n_rows << std::endl;
 
 		if (n_rows > 0)
 		{
 		   if ((row = mysql_fetch_row(result)) != NULL)
 		   {
-	    	  DEBUG_STREAM << "DataBase::ExportDevice(): device "<< tmp_device << " server name " << row[0] << endl;
+	    	  DEBUG_STREAM << "DataBase::ExportDevice(): device "<< tmp_device << " server name " << row[0] << std::endl;
 	    	  tmp_server = row[0];
 		   }
 		}
 		else
 		{
-	    	 INFO_STREAM << "DataBase::ExportDevice(): device not defined !" << endl;
+	    	 INFO_STREAM << "DataBase::ExportDevice(): device not defined !" << std::endl;
   	 		 TangoSys_OMemStream o;
 			 o << "device " << tmp_device << " not defined in the database !";
 	    	 mysql_free_result(result);
@@ -1941,7 +1941,7 @@ void DataBase::db_export_device(const Tango::DevVarStringArray *argin)
 	                 << "\',host=\'" << tmp_host << "\',pid=\'" << tmp_pid
 					 << "\',version=\'" << tmp_version
 					 << "\',started=NOW() where name LIKE \'" << tmp_device << "\'";
-		DEBUG_STREAM << "DataBase::ExportDevice(): sql_query " << sql_query_stream.str() << endl;
+		DEBUG_STREAM << "DataBase::ExportDevice(): sql_query " << sql_query_stream.str() << std::endl;
 
 		simple_query(sql_query_stream.str(),"db_export_device()",al.get_con_nb());
 
@@ -1950,7 +1950,7 @@ void DataBase::db_export_device(const Tango::DevVarStringArray *argin)
     	sql_query_stream.str("");
 		sql_query_stream << "UPDATE server set host=\'" << tmp_host << "\' where name LIKE \'"
 	                 << tmp_server << "\'";
-    	DEBUG_STREAM << "DataBase::ExportDevice(): sql_query " << sql_query_stream.str() << endl;
+    	DEBUG_STREAM << "DataBase::ExportDevice(): sql_query " << sql_query_stream.str() << std::endl;
 
 		simple_query(sql_query_stream.str(),"db_export_device()",al.get_con_nb());
 	}
@@ -1961,7 +1961,7 @@ void DataBase::db_export_device(const Tango::DevVarStringArray *argin)
 		//	Update host's starter to update controlled servers list
 		vector<string>	hosts;
 		hosts.push_back(tmp_host);
-		DEBUG_STREAM << "New Host is " << tmp_host << endl;
+		DEBUG_STREAM << "New Host is " << tmp_host << std::endl;
 
 		if (previous_host!=""      &&
 			previous_host!="nada"  &&
@@ -2009,7 +2009,7 @@ void DataBase::db_export_event(const Tango::DevVarStringArray *argin)
 					       (const char *)"DataBase::db_export_event()");
 	}
 
-	INFO_STREAM << "DataBase::db_export_event(): put " << export_info->length()-1 << " export info for event " << (*export_info)[0] << endl;
+	INFO_STREAM << "DataBase::db_export_event(): put " << export_info->length()-1 << " export info for event " << (*export_info)[0] << std::endl;
 
 	tmp_event = (*export_info)[0];
 	for (unsigned  int i=0; i<tmp_event.length(); i++) {
@@ -2027,7 +2027,7 @@ void DataBase::db_export_event(const Tango::DevVarStringArray *argin)
 		AutoLock al("LOCK TABLE event WRITE",this);
 
 		sql_query_stream << "DELETE FROM event WHERE name=\"" << tmp_event << "\"";
-   		DEBUG_STREAM << "DataBase::db_export_event(): sql_query " << sql_query_stream.str() << endl;
+   		DEBUG_STREAM << "DataBase::db_export_event(): sql_query " << sql_query_stream.str() << std::endl;
 		simple_query(sql_query_stream.str(),"db_export_event()",al.get_con_nb());
 
 // update the new value for this tuple
@@ -2037,7 +2037,7 @@ void DataBase::db_export_event(const Tango::DevVarStringArray *argin)
 	                 << "\',exported=1,ior=\'" << tmp_ior << "\',host=\'" << tmp_host
 					 << "\',server=\'" << tmp_event << "\',pid=\'" << tmp_pid
 					 << "\',version=\'" << tmp_version << "\',started=NOW();";
-		DEBUG_STREAM << "DataBase::export_event(): sql_query " << sql_query_stream.str() << endl;
+		DEBUG_STREAM << "DataBase::export_event(): sql_query " << sql_query_stream.str() << std::endl;
 		simple_query(sql_query_stream.str(),"db_export_event()",al.get_con_nb());
 	}
 
@@ -2079,12 +2079,12 @@ Tango::DevString DataBase::db_get_alias_device(Tango::DevString argin)
 		tmp_argin = replace_wildcard(argin);
 		sql_query_stream << "SELECT name FROM device WHERE alias LIKE \"" << tmp_argin << "\"";
 	}
-	DEBUG_STREAM << "DataBase::db_get_alias_device(): sql_query " << sql_query_stream.str() << endl;
+	DEBUG_STREAM << "DataBase::db_get_alias_device(): sql_query " << sql_query_stream.str() << std::endl;
 
 	result = query(sql_query_stream.str(),"db_get_alias_device()");
 
 	n_rows = mysql_num_rows(result);
-	DEBUG_STREAM << "DataBase::db_get_alias_device(): mysql_num_rows() " << n_rows << endl;
+	DEBUG_STREAM << "DataBase::db_get_alias_device(): mysql_num_rows() " << n_rows << std::endl;
 	if (n_rows > 0)
 	{
 		if ((row = mysql_fetch_row(result)) != NULL)
@@ -2099,7 +2099,7 @@ Tango::DevString DataBase::db_get_alias_device(Tango::DevString argin)
         TangoSys_OMemStream o;
 	    o << "No device found for alias \'" << argin << "\'";
 		string msg = o.str();
-		WARN_STREAM << msg << endl;
+		WARN_STREAM << msg << std::endl;
 		Tango::Except::throw_exception((const char *)DB_DeviceNotDefined,
 	   				                   msg,
 					                   (const char *)"DataBase::db_get_alias_device()");
@@ -2131,23 +2131,23 @@ Tango::DevString DataBase::db_get_attribute_alias(Tango::DevString argin)
 	long n_rows=0;
 	argout  = new char[256];
 
-	INFO_STREAM << "DataBase::db_get_attribute_alias(): put " << argin << endl;
+	INFO_STREAM << "DataBase::db_get_attribute_alias(): put " << argin << std::endl;
 
 // first check to see if this alias exists
 
 	sql_query_stream << "SELECT name from attribute_alias WHERE alias LIKE \'" << argin << "\' ";
-	DEBUG_STREAM << "DataBase::db_get_attribute_alias(): sql_query " << sql_query_stream.str() << endl;
+	DEBUG_STREAM << "DataBase::db_get_attribute_alias(): sql_query " << sql_query_stream.str() << std::endl;
 
 	result = query(sql_query_stream.str(),"db_get_attribute_alias()");
 
 	n_rows = mysql_num_rows(result);
-	DEBUG_STREAM << "DataBase::db_get_attribute_alias(): mysql_num_rows() " << n_rows << endl;
+	DEBUG_STREAM << "DataBase::db_get_attribute_alias(): mysql_num_rows() " << n_rows << std::endl;
 
 	if (n_rows > 0)
 	{
         if ((row = mysql_fetch_row(result)) != NULL)
         {
-            DEBUG_STREAM << "DataBase::db_get_attribute_alias(): attribute name "<< row[0] << endl;
+            DEBUG_STREAM << "DataBase::db_get_attribute_alias(): attribute name "<< row[0] << std::endl;
             strcpy(argout,row[0]);
 		}
 	}
@@ -2192,7 +2192,7 @@ Tango::DevVarStringArray *DataBase::db_get_attribute_alias_list(Tango::DevString
 	int n_rows;
 
 	INFO_STREAM << "DataBase::db_get_attribute_alias_list(): alias " << argin;
-	WARN_STREAM << " wildcard " << argin << endl;
+	WARN_STREAM << " wildcard " << argin << std::endl;
 
 	if (argin == NULL)
 	{
@@ -2204,12 +2204,12 @@ Tango::DevVarStringArray *DataBase::db_get_attribute_alias_list(Tango::DevString
 		sql_query_stream << "SELECT DISTINCT alias,attribute FROM attribute_alias WHERE alias LIKE \""
 		                 << tmp_wildcard << "\" ORDER BY attribute";
 	}
-	DEBUG_STREAM << "DataBase::db_get_attribute_alias_list(): sql_query " << sql_query_stream.str() << endl;
+	DEBUG_STREAM << "DataBase::db_get_attribute_alias_list(): sql_query " << sql_query_stream.str() << std::endl;
 
 	result = query(sql_query_stream.str(),"db_get_attribute_alias_list()");
 
 	n_rows = mysql_num_rows(result);
-	DEBUG_STREAM << "DataBase::db_get_attribute_alias_list(): mysql_num_rows() " << n_rows << endl;
+	DEBUG_STREAM << "DataBase::db_get_attribute_alias_list(): mysql_num_rows() " << n_rows << std::endl;
 	argout = new Tango::DevVarStringArray;
 
 	if (n_rows > 0)
@@ -2220,7 +2220,7 @@ Tango::DevVarStringArray *DataBase::db_get_attribute_alias_list(Tango::DevString
 	   {
 	      if ((row = mysql_fetch_row(result)) != NULL)
 	      {
-	         DEBUG_STREAM << "DataBase::db_get_attribute_alias_list(): attribute[ "<< i << "] attribute " << row[0] << endl;
+	         DEBUG_STREAM << "DataBase::db_get_attribute_alias_list(): attribute[ "<< i << "] attribute " << row[0] << std::endl;
 	         (*argout)[i]   = CORBA::string_dup(row[0]);
 	      }
 	   }
@@ -2260,7 +2260,7 @@ Tango::DevVarStringArray *DataBase::db_get_class_attribute_list(const Tango::Dev
 	string tmp_wildcard;
 
 	class_name = (*class_wildcard)[0];
-	INFO_STREAM << "DataBase::db_get_class_attribute(): get attributes for class " << class_name << endl;
+	INFO_STREAM << "DataBase::db_get_class_attribute(): get attributes for class " << class_name << std::endl;
 
 	wildcard = (*class_wildcard)[1];
 	if (wildcard == NULL)
@@ -2277,12 +2277,12 @@ Tango::DevVarStringArray *DataBase::db_get_class_attribute_list(const Tango::Dev
 		sql_query_stream << "SELECT DISTINCT attribute FROM property_attribute_class WHERE class = \""
 		                 << class_name << "\"  AND attribute like \"" << tmp_wildcard << "\"";
 	}
-	DEBUG_STREAM << "DataBase::GetClassAttributeList(): sql_query " << sql_query_stream.str() << endl;
+	DEBUG_STREAM << "DataBase::GetClassAttributeList(): sql_query " << sql_query_stream.str() << std::endl;
 
 	result = query(sql_query_stream.str(),"db_get_class_attribute_list()");
 
 	n_rows = mysql_num_rows(result);
-	DEBUG_STREAM << "DataBase::GetClassAttributeList(): num_rows() " << n_rows << endl;
+	DEBUG_STREAM << "DataBase::GetClassAttributeList(): num_rows() " << n_rows << std::endl;
 	if (n_rows > 0)
 	{
 		  int n_attrs=0;
@@ -2290,7 +2290,7 @@ Tango::DevVarStringArray *DataBase::db_get_class_attribute_list(const Tango::Dev
 	      {
 	         if ((row = mysql_fetch_row(result)) != NULL)
 	         {
-	            DEBUG_STREAM << "DataBase::GetClassAttributeList(): attribute[ "<< j << "] " << row[0] << endl;
+	            DEBUG_STREAM << "DataBase::GetClassAttributeList(): attribute[ "<< j << "] " << row[0] << std::endl;
 		    	n_attrs++;
 		    	argout->length(n_attrs);
 	            (*argout)[n_attrs-1] = CORBA::string_dup(row[0]);
@@ -2299,7 +2299,7 @@ Tango::DevVarStringArray *DataBase::db_get_class_attribute_list(const Tango::Dev
 	}
 	mysql_free_result(result);
 
-	DEBUG_STREAM << "DataBase::GetClassAttributeList(): argout->length() "<< argout->length() << endl;
+	DEBUG_STREAM << "DataBase::GetClassAttributeList(): argout->length() "<< argout->length() << std::endl;
 
 	/*----- PROTECTED REGION END -----*/	//	DataBase::db_get_class_attribute_list
 	return argout;
@@ -2337,7 +2337,7 @@ Tango::DevVarStringArray *DataBase::db_get_class_attribute_property(const Tango:
 	argout = new Tango::DevVarStringArray;
 	const char *tmp_class, *tmp_attribute;
 
-	INFO_STREAM << "DataBase::GetAttributeProperty(): get " << property_names->length()-1 << " attributes for class " << (*property_names)[0] << endl;
+	INFO_STREAM << "DataBase::GetAttributeProperty(): get " << property_names->length()-1 << " attributes for class " << (*property_names)[0] << std::endl;
 
 	tmp_class = (*property_names)[0];
 #ifdef TANGO_LONG32
@@ -2356,12 +2356,12 @@ Tango::DevVarStringArray *DataBase::db_get_class_attribute_property(const Tango:
 	   sql_query_stream.str("");
 	   sql_query_stream << "SELECT name,value FROM property_attribute_class WHERE class = \""
 	                    << tmp_class << "\" AND attribute LIKE \"" << tmp_attribute << "\" ";
-	   DEBUG_STREAM << "DataBase::GetAttributeProperty(): sql_query " << sql_query_stream.str() << endl;
+	   DEBUG_STREAM << "DataBase::GetAttributeProperty(): sql_query " << sql_query_stream.str() << std::endl;
 
 	   result = query(sql_query_stream.str(),"db_get_class_attribute_property()");
 
 	   n_rows = mysql_num_rows(result);
-	   DEBUG_STREAM << "DataBase::GetAttributeProperty(): mysql_num_rows() " << n_rows << endl;
+	   DEBUG_STREAM << "DataBase::GetAttributeProperty(): mysql_num_rows() " << n_rows << std::endl;
 	   sprintf(n_rows_str,"%d",n_rows);
 	   n_props = n_props+2;
 	   argout->length(n_props);
@@ -2374,7 +2374,7 @@ Tango::DevVarStringArray *DataBase::db_get_class_attribute_property(const Tango:
 	      {
 	         if ((row = mysql_fetch_row(result)) != NULL)
 	         {
-	            DEBUG_STREAM << "DataBase::GetAttributeProperty(): property[ "<< i << "] count " << row[0] << " value " << row[1] << endl;
+	            DEBUG_STREAM << "DataBase::GetAttributeProperty(): property[ "<< i << "] count " << row[0] << " value " << row[1] << std::endl;
 	            n_props = n_props+2;
 	            argout->length(n_props);
 	            (*argout)[n_props-2] = CORBA::string_dup(row[0]);
@@ -2385,7 +2385,7 @@ Tango::DevVarStringArray *DataBase::db_get_class_attribute_property(const Tango:
 	   mysql_free_result(result);
 	}
 
-	DEBUG_STREAM << "DataBase::GetClassProperty(): argout->length() "<< argout->length() << endl;
+	DEBUG_STREAM << "DataBase::GetClassProperty(): argout->length() "<< argout->length() << std::endl;
 
 	/*----- PROTECTED REGION END -----*/	//	DataBase::db_get_class_attribute_property
 	return argout;
@@ -2425,7 +2425,7 @@ Tango::DevVarStringArray *DataBase::db_get_class_attribute_property2(const Tango
 	//	See "TANGO Device Server Programmer's Manual"
 	//		(chapter : Writing a TANGO DS / Exchanging data)
 	//------------------------------------------------------------
-	DEBUG_STREAM << "DataBase::db_get_class_attribute_property2(): entering... !" << endl;
+	DEBUG_STREAM << "DataBase::db_get_class_attribute_property2(): entering... !" << std::endl;
 
 	//	Add your own code to control device here
 
@@ -2439,7 +2439,7 @@ Tango::DevVarStringArray *DataBase::db_get_class_attribute_property2(const Tango
 	argout = new Tango::DevVarStringArray;
 	const char *tmp_class, *tmp_attribute;
 
-	INFO_STREAM << "DataBase::GetClassAttributeProperty2(): get " << property_names->length()-1 << " properties for device " << (*property_names)[0] << endl;
+	INFO_STREAM << "DataBase::GetClassAttributeProperty2(): get " << property_names->length()-1 << " properties for device " << (*property_names)[0] << std::endl;
 
 	tmp_class = (*property_names)[0];
 #ifdef TANGO_LONG32
@@ -2459,12 +2459,12 @@ Tango::DevVarStringArray *DataBase::db_get_class_attribute_property2(const Tango
 		sql_query_stream << "SELECT name,value FROM property_attribute_class WHERE class = \""
 		                 << tmp_class << "\" AND attribute LIKE \"" << tmp_attribute
 						 << "\" ORDER BY name,count";
-	   	DEBUG_STREAM << "DataBase::GetClassAttributeProperty2(): sql_query " << sql_query_stream.str() << endl;
+	   	DEBUG_STREAM << "DataBase::GetClassAttributeProperty2(): sql_query " << sql_query_stream.str() << std::endl;
 
 		result = query(sql_query_stream.str(),"db_get_class_attribute_property2()");
 
 	   	n_rows = mysql_num_rows(result);
-	   	DEBUG_STREAM << "DataBase::GetClassAttributeProperty2(): mysql_num_rows() " << n_rows << endl;
+	   	DEBUG_STREAM << "DataBase::GetClassAttributeProperty2(): mysql_num_rows() " << n_rows << std::endl;
 	   	n_props = n_props+2;
 	   	argout->length(n_props);
 	   	(*argout)[n_props-2] = CORBA::string_dup(tmp_attribute);
@@ -2494,7 +2494,7 @@ Tango::DevVarStringArray *DataBase::db_get_class_attribute_property2(const Tango
 						else
 							new_prop = false;
 					}
-//	            			DEBUG_STREAM << "DataBase::GetClassAttributeProperty2(): property[ "<< i << "] count " << row[0] << " value " << row[1] << endl;
+//	            			DEBUG_STREAM << "DataBase::GetClassAttributeProperty2(): property[ "<< i << "] count " << row[0] << " value " << row[1] << std::endl;
 					if (new_prop == true)
 					{
 						n_props = n_props + 3;
@@ -2531,7 +2531,7 @@ Tango::DevVarStringArray *DataBase::db_get_class_attribute_property2(const Tango
 	   	mysql_free_result(result);
 	}
 
-	DEBUG_STREAM << "DataBase::GetClassAttributeProperty2(): argout->length() "<< argout->length() << endl;
+	DEBUG_STREAM << "DataBase::GetClassAttributeProperty2(): argout->length() "<< argout->length() << std::endl;
 
 	/*----- PROTECTED REGION END -----*/	//	DataBase::db_get_class_attribute_property2
 	return argout;
@@ -2569,7 +2569,7 @@ Tango::DevVarStringArray *DataBase::db_get_class_attribute_property_hist(const T
 
 	if (argin->length() != 3)
 	{
-	   WARN_STREAM << "DataBase::DbGetClassAttributePropertyHist(): incorrect number of input arguments " << endl;
+	   WARN_STREAM << "DataBase::DbGetClassAttributePropertyHist(): incorrect number of input arguments " << std::endl;
 	   Tango::Except::throw_exception((const char *)DB_IncorrectArguments,
 	   				  (const char *)"incorrect no. of input arguments, needs 3 (class,attribute,property)",
 					  (const char *)"DataBase::DbGetClassAttributePropertyHist()");
@@ -2660,7 +2660,7 @@ Tango::DevString DataBase::db_get_class_for_device(Tango::DevString argin)
 	TangoSys_MemStream	tms;
 	tms << "SELECT DISTINCT class FROM device WHERE name=\""
 				<< argin <<  "\"";
-	DEBUG_STREAM << "DataBase::db_get_class_for_device(): sql_query " << tms.str() << endl;
+	DEBUG_STREAM << "DataBase::db_get_class_for_device(): sql_query " << tms.str() << std::endl;
 
 	MYSQL_RES *result = query(tms.str(), "db_get_class_for_device()");
 	int	n_rows = mysql_num_rows(result);
@@ -2685,7 +2685,7 @@ Tango::DevString DataBase::db_get_class_for_device(Tango::DevString argin)
 		}
 	mysql_free_result(result);
 
-	DEBUG_STREAM << "Class " << argout << " found for " << argin << endl;
+	DEBUG_STREAM << "Class " << argout << " found for " << argin << std::endl;
 
 	/*----- PROTECTED REGION END -----*/	//	DataBase::db_get_class_for_device
 	return argout;
@@ -2755,17 +2755,17 @@ Tango::DevVarStringArray *DataBase::db_get_class_list(Tango::DevString argin)
 	int n_rows;
 	string tmp_server;
 
-	INFO_STREAM << "DataBase::db_get_class_list(): server " << server << endl;
+	INFO_STREAM << "DataBase::db_get_class_list(): server " << server << std::endl;
 
 	tmp_server = replace_wildcard(server);
 	sql_query_stream << "SELECT DISTINCT class FROM device WHERE class LIKE \""
 	                 << tmp_server << "\" ORDER BY class";
-	DEBUG_STREAM << "DataBase::db_get_class_list(): sql_query " << sql_query_stream.str() << endl;
+	DEBUG_STREAM << "DataBase::db_get_class_list(): sql_query " << sql_query_stream.str() << std::endl;
 
 	result = query(sql_query_stream.str(),"db_get_class_list()");
 
 	n_rows = mysql_num_rows(result);
-	DEBUG_STREAM << "DataBase::db_get_class_list(): mysql_num_rows() " << n_rows << endl;
+	DEBUG_STREAM << "DataBase::db_get_class_list(): mysql_num_rows() " << n_rows << std::endl;
 	argout = new Tango::DevVarStringArray;
 
 	if (n_rows > 0)
@@ -2776,7 +2776,7 @@ Tango::DevVarStringArray *DataBase::db_get_class_list(Tango::DevString argin)
 	   {
 	      if ((row = mysql_fetch_row(result)) != NULL)
 	      {
-//	         DEBUG_STREAM << "DataBase::db_get_class_list(): row[ "<< i << "] class " << row[0] << endl;
+//	         DEBUG_STREAM << "DataBase::db_get_class_list(): row[ "<< i << "] class " << row[0] << std::endl;
 	         (*argout)[i]   = CORBA::string_dup(row[0]);
 	      }
 	   }
@@ -2822,7 +2822,7 @@ Tango::DevVarStringArray *DataBase::db_get_class_property(const Tango::DevVarStr
 	argout = new Tango::DevVarStringArray;
 	const char *tmp_class, *tmp_name;
 
-	INFO_STREAM << "DataBase::GetClassProperty(): get " << property_names->length()-1 << " properties for device " << (*property_names)[0] << endl;
+	INFO_STREAM << "DataBase::GetClassProperty(): get " << property_names->length()-1 << " properties for device " << (*property_names)[0] << std::endl;
 
 	tmp_class = (*property_names)[0];
 #ifdef TANGO_LONG32
@@ -2841,12 +2841,12 @@ Tango::DevVarStringArray *DataBase::db_get_class_property(const Tango::DevVarStr
 	   sql_query_stream.str("");
 	   sql_query_stream << "SELECT count,value FROM property_class WHERE class = \""
 	                    << tmp_class << "\" AND name LIKE \"" << tmp_name << "\" ORDER BY count";
-	   DEBUG_STREAM << "DataBase::GetClassProperty(): sql_query " << sql_query_stream.str() << endl;
+	   DEBUG_STREAM << "DataBase::GetClassProperty(): sql_query " << sql_query_stream.str() << std::endl;
 
 	   result = query(sql_query_stream.str(),"db_get_class_property()");
 
 	   n_rows = mysql_num_rows(result);
-	   DEBUG_STREAM << "DataBase::GetClassProperty(): mysql_num_rows() " << n_rows << endl;
+	   DEBUG_STREAM << "DataBase::GetClassProperty(): mysql_num_rows() " << n_rows << std::endl;
 	   sprintf(n_rows_str,"%d",n_rows);
 	   n_props = n_props+2;
 	   argout->length(n_props);
@@ -2859,7 +2859,7 @@ Tango::DevVarStringArray *DataBase::db_get_class_property(const Tango::DevVarStr
 	      {
 	         if ((row = mysql_fetch_row(result)) != NULL)
 	         {
-	            DEBUG_STREAM << "DataBase::GetClassProperty(): property[ "<< i << "] count " << row[0] << " value " << row[1] << endl;
+	            DEBUG_STREAM << "DataBase::GetClassProperty(): property[ "<< i << "] count " << row[0] << " value " << row[1] << std::endl;
 		    	n_props++;
 		    	argout->length(n_props);
 	            (*argout)[n_props-1] = CORBA::string_dup(row[1]);
@@ -2869,7 +2869,7 @@ Tango::DevVarStringArray *DataBase::db_get_class_property(const Tango::DevVarStr
 	   mysql_free_result(result);
 	}
 
-	DEBUG_STREAM << "DataBase::GetClassProperty(): argout->length() "<< argout->length() << endl;
+	DEBUG_STREAM << "DataBase::GetClassProperty(): argout->length() "<< argout->length() << std::endl;
 
 	/*----- PROTECTED REGION END -----*/	//	DataBase::db_get_class_property
 	return argout;
@@ -2904,7 +2904,7 @@ Tango::DevVarStringArray *DataBase::db_get_class_property_hist(const Tango::DevV
 
 	if (argin->length() != 2)
 	{
-	   WARN_STREAM << "DataBase::DbGetClassPropertyHist(): incorrect number of input arguments " << endl;
+	   WARN_STREAM << "DataBase::DbGetClassPropertyHist(): incorrect number of input arguments " << std::endl;
 	   Tango::Except::throw_exception((const char *)DB_IncorrectArguments,
 	   				  (const char *)"incorrect no. of input arguments, needs 2 (class,property)",
 					  (const char *)"DataBase::DbGetClassPropertyHist()");
@@ -2996,7 +2996,7 @@ Tango::DevVarStringArray *DataBase::db_get_class_property_list(Tango::DevString 
 	GetTime(before);
 
 
-	INFO_STREAM << "DataBase::db_get_class_property_list(): class " << class_name << endl;
+	INFO_STREAM << "DataBase::db_get_class_property_list(): class " << class_name << std::endl;
 
 	if (class_name == NULL)
 	{
@@ -3007,12 +3007,12 @@ Tango::DevVarStringArray *DataBase::db_get_class_property_list(Tango::DevString 
 		sql_query_stream << "SELECT DISTINCT name FROM property_class WHERE class LIKE \""
 		                 << class_name << "\" ORDER BY name";
 	}
-	DEBUG_STREAM << "DataBase::db_get_class_property_list(): sql_query " << sql_query_stream.str() << endl;
+	DEBUG_STREAM << "DataBase::db_get_class_property_list(): sql_query " << sql_query_stream.str() << std::endl;
 
 	result = query(sql_query_stream.str(),"db_get_class_property_list()");
 
 	n_rows = mysql_num_rows(result);
-	DEBUG_STREAM << "DataBase::db_get_class_property_list(): mysql_num_rows() " << n_rows << endl;
+	DEBUG_STREAM << "DataBase::db_get_class_property_list(): mysql_num_rows() " << n_rows << std::endl;
 	argout = new Tango::DevVarStringArray;
 
 	if (n_rows > 0)
@@ -3023,7 +3023,7 @@ Tango::DevVarStringArray *DataBase::db_get_class_property_list(Tango::DevString 
 	   {
 	      if ((row = mysql_fetch_row(result)) != NULL)
 	      {
-	         DEBUG_STREAM << "DataBase::db_get_class_property_list(): property[ "<< i << "] alias " << row[0] << endl;
+	         DEBUG_STREAM << "DataBase::db_get_class_property_list(): property[ "<< i << "] alias " << row[0] << std::endl;
 	         (*argout)[i]   = CORBA::string_dup(row[0]);
 	      }
 	   }
@@ -3063,11 +3063,11 @@ Tango::DevString DataBase::db_get_device_alias(Tango::DevString argin)
 
 	argout = NULL;
 
-	INFO_STREAM << "DataBase::db_get_device_alias(): devname " << devname << endl;
+	INFO_STREAM << "DataBase::db_get_device_alias(): devname " << devname << std::endl;
 	if (!check_device_name(devname))
 	{
          	WARN_STREAM << "DataBase::db_get_device_alias(): device name  " << devname << " incorrect ";
-         	WARN_STREAM << endl;
+         	WARN_STREAM << std::endl;
          	Tango::Except::throw_exception((const char *)DB_IncorrectDeviceName,
 					       (const char *)"failed to find alias, device name incorrect",
 					       (const char *)"DataBase::db_get_device_alias()");
@@ -3076,12 +3076,12 @@ Tango::DevString DataBase::db_get_device_alias(Tango::DevString argin)
 	tmp_devname = replace_wildcard(devname.c_str());
 	sql_query_stream << "SELECT DISTINCT alias FROM device WHERE name LIKE \"" << tmp_devname
 	                 << "\" ORDER BY alias";
-	DEBUG_STREAM << "DataBase::db_get_device_alias(): sql_query " << sql_query_stream.str() << endl;
+	DEBUG_STREAM << "DataBase::db_get_device_alias(): sql_query " << sql_query_stream.str() << std::endl;
 
 	result = query(sql_query_stream.str(),"db_get_device_alias()");
 
 	n_rows = mysql_num_rows(result);
-	DEBUG_STREAM << "DataBase::db_get_device_alias_(): mysql_num_rows() " << n_rows << endl;
+	DEBUG_STREAM << "DataBase::db_get_device_alias_(): mysql_num_rows() " << n_rows << std::endl;
 
 	if (n_rows > 0)
 	{
@@ -3093,7 +3093,7 @@ Tango::DevString DataBase::db_get_device_alias(Tango::DevString argin)
   	            TangoSys_OMemStream o;
 				o << "No alias found for device \'" << devname << "\'";
 				string msg = o.str();
-				WARN_STREAM << msg << endl;
+				WARN_STREAM << msg << std::endl;
 				Tango::Except::throw_exception((const char *)DB_AliasNotDefined,
 	   						                   msg,
 							                   (const char *)"DataBase::db_get_device_alias()");
@@ -3108,7 +3108,7 @@ Tango::DevString DataBase::db_get_device_alias(Tango::DevString argin)
         TangoSys_OMemStream o;
 		o << "No alias found for device \'" << devname << "\'";
 		string msg = o.str();
-		WARN_STREAM << msg << endl;
+		WARN_STREAM << msg << std::endl;
 		Tango::Except::throw_exception((const char *)DB_AliasNotDefined,
 	   				                   msg,
 					                   (const char *)"DataBase::db_get_device_alias()");
@@ -3141,7 +3141,7 @@ Tango::DevVarStringArray *DataBase::db_get_device_alias_list(Tango::DevString ar
 	MYSQL_ROW row;
 	int n_rows;
 
-	INFO_STREAM << "DataBase::db_get_device_alias_list(): wild card " << wildcard << endl;
+	INFO_STREAM << "DataBase::db_get_device_alias_list(): wild card " << wildcard << std::endl;
 
 	if (wildcard == NULL)
 	{
@@ -3153,12 +3153,12 @@ Tango::DevVarStringArray *DataBase::db_get_device_alias_list(Tango::DevString ar
 		sql_query_stream << "SELECT DISTINCT alias FROM device WHERE alias LIKE \"" << tmp_wildcard
 		                 << "\" ORDER BY alias";
 	}
-	DEBUG_STREAM << "DataBase::db_get_device_alias_list(): sql_query " << sql_query_stream.str() << endl;
+	DEBUG_STREAM << "DataBase::db_get_device_alias_list(): sql_query " << sql_query_stream.str() << std::endl;
 
 	result = query(sql_query_stream.str(),"db_get_device_alias_list()");
 
 	n_rows = mysql_num_rows(result);
-	DEBUG_STREAM << "DataBase::db_get_device_alias_list(): mysql_num_rows() " << n_rows << endl;
+	DEBUG_STREAM << "DataBase::db_get_device_alias_list(): mysql_num_rows() " << n_rows << std::endl;
 	argout = new Tango::DevVarStringArray;
 
 	if (n_rows > 0)
@@ -3169,7 +3169,7 @@ Tango::DevVarStringArray *DataBase::db_get_device_alias_list(Tango::DevString ar
 	   {
 	      if ((row = mysql_fetch_row(result)) != NULL)
 	      {
-//	         DEBUG_STREAM << "DataBase::db_get_device_alias_list(): row[ "<< i << "] alias " << row[0] << endl;
+//	         DEBUG_STREAM << "DataBase::db_get_device_alias_list(): row[ "<< i << "] alias " << row[0] << std::endl;
 	         (*argout)[i]   = CORBA::string_dup(row[0]);
 	      }
 	   }
@@ -3210,7 +3210,7 @@ Tango::DevVarStringArray *DataBase::db_get_device_attribute_list(const Tango::De
 	device = (*device_wildcard)[0];
 	wildcard = (*device_wildcard)[1];
 	INFO_STREAM << "DataBase::db_get_device_attribute_list(): device " << device;
-	WARN_STREAM << " wildcard " << wildcard << endl;
+	WARN_STREAM << " wildcard " << wildcard << std::endl;
 
 	if (wildcard == NULL)
 	{
@@ -3223,12 +3223,12 @@ Tango::DevVarStringArray *DataBase::db_get_device_attribute_list(const Tango::De
 		sql_query_stream << "SELECT DISTINCT attribute FROM property_attribute_device WHERE device=\""
 		                 << device << "\" AND attribute LIKE \"" << tmp_wildcard << "\" ORDER BY attribute";
 	}
-	DEBUG_STREAM << "DataBase::db_get_device_attrribute_list(): sql_query " << sql_query_stream.str() << endl;
+	DEBUG_STREAM << "DataBase::db_get_device_attrribute_list(): sql_query " << sql_query_stream.str() << std::endl;
 
 	result = query(sql_query_stream.str(),"db_get_device_attribute_list()");
 
 	n_rows = mysql_num_rows(result);
-	DEBUG_STREAM << "DataBase::db_get_device_attribute_list(): mysql_num_rows() " << n_rows << endl;
+	DEBUG_STREAM << "DataBase::db_get_device_attribute_list(): mysql_num_rows() " << n_rows << std::endl;
 	argout = new Tango::DevVarStringArray;
 
 	if (n_rows > 0)
@@ -3239,7 +3239,7 @@ Tango::DevVarStringArray *DataBase::db_get_device_attribute_list(const Tango::De
 	   {
 	      if ((row = mysql_fetch_row(result)) != NULL)
 	      {
-	         DEBUG_STREAM << "DataBase::db_get_device_attribute_list(): attribute[ "<< i << "] attribute " << row[0] << endl;
+	         DEBUG_STREAM << "DataBase::db_get_device_attribute_list(): attribute[ "<< i << "] attribute " << row[0] << std::endl;
 	         (*argout)[i]   = CORBA::string_dup(row[0]);
 	      }
 	   }
@@ -3288,7 +3288,7 @@ Tango::DevVarStringArray *DataBase::db_get_device_attribute_property(const Tango
 	GetTime(before);
 
 
-	INFO_STREAM << "DataBase::GetAttributeProperty(): get " << property_names->length()-1 << " properties for device " << (*property_names)[0] << endl;
+	INFO_STREAM << "DataBase::GetAttributeProperty(): get " << property_names->length()-1 << " properties for device " << (*property_names)[0] << std::endl;
 
 	tmp_device = (*property_names)[0];
 #ifdef TANGO_LONG32
@@ -3307,12 +3307,12 @@ Tango::DevVarStringArray *DataBase::db_get_device_attribute_property(const Tango
 	   sql_query_stream.str("");
 	   sql_query_stream << "SELECT name,value FROM property_attribute_device WHERE device = \""
 	                    << tmp_device << "\" AND attribute LIKE \"" << tmp_attribute << "\" ";
-	   DEBUG_STREAM << "DataBase::GetAttributeProperty(): sql_query " << sql_query_stream.str() << endl;
+	   DEBUG_STREAM << "DataBase::GetAttributeProperty(): sql_query " << sql_query_stream.str() << std::endl;
 
 	   result = query(sql_query_stream.str(),"db_get_device_attribute_property()");
 
 	   n_rows = mysql_num_rows(result);
-	   DEBUG_STREAM << "DataBase::GetAttributeProperty(): mysql_num_rows() " << n_rows << endl;
+	   DEBUG_STREAM << "DataBase::GetAttributeProperty(): mysql_num_rows() " << n_rows << std::endl;
 	   sprintf(n_rows_str,"%d",n_rows);
 	   n_props = n_props+2;
 	   argout->length(n_props);
@@ -3325,7 +3325,7 @@ Tango::DevVarStringArray *DataBase::db_get_device_attribute_property(const Tango
 	      {
 	         if ((row = mysql_fetch_row(result)) != NULL)
 	         {
-	            DEBUG_STREAM << "DataBase::GetAttributeProperty(): property[ "<< i << "] count " << row[0] << " value " << row[1] << endl;
+	            DEBUG_STREAM << "DataBase::GetAttributeProperty(): property[ "<< i << "] count " << row[0] << " value " << row[1] << std::endl;
 	   	    	n_props = n_props+2;
 	   	    	argout->length(n_props);
 	            (*argout)[n_props-2] = CORBA::string_dup(row[0]);
@@ -3336,7 +3336,7 @@ Tango::DevVarStringArray *DataBase::db_get_device_attribute_property(const Tango
 	   mysql_free_result(result);
 	}
 
-	DEBUG_STREAM << "DataBase::GetDeviceProperty(): argout->length() "<< argout->length() << endl;
+	DEBUG_STREAM << "DataBase::GetDeviceProperty(): argout->length() "<< argout->length() << std::endl;
 
 	GetTime(after);
 	update_timing_stats(before, after, "DbGetDeviceAttributeProperty");
@@ -3388,7 +3388,7 @@ Tango::DevVarStringArray *DataBase::db_get_device_attribute_property2(const Tang
 	TimeVal	before, after;
 	GetTime(before);
 
-	INFO_STREAM << "DataBase::GetDeviceAttributeProperty2(): get " << property_names->length()-1 << " properties for device " << (*property_names)[0] << endl;
+	INFO_STREAM << "DataBase::GetDeviceAttributeProperty2(): get " << property_names->length()-1 << " properties for device " << (*property_names)[0] << std::endl;
 
 	tmp_device = (*property_names)[0];
 #ifdef TANGO_LONG32
@@ -3408,11 +3408,11 @@ Tango::DevVarStringArray *DataBase::db_get_device_attribute_property2(const Tang
 
 	bool all_attr = false;
 	sql_query_stream << "SELECT COUNT(DISTINCT attribute) FROM property_attribute_device WHERE device = \"" << tmp_device << "\"";
-	DEBUG_STREAM << "Database::GetDeviceAttributeProperty2(): sql_query " << sql_query_stream.str() << endl;
+	DEBUG_STREAM << "Database::GetDeviceAttributeProperty2(): sql_query " << sql_query_stream.str() << std::endl;
 
 	result = query(sql_query_stream.str(),"db_get_device_attribute_property2()");
 	n_rows = mysql_num_rows(result);
-	DEBUG_STREAM << "DataBase::GetDeviceAttributeProperty2(): mysql_num_rows() " << n_rows << endl;
+	DEBUG_STREAM << "DataBase::GetDeviceAttributeProperty2(): mysql_num_rows() " << n_rows << std::endl;
 
 	if (n_rows != 0)
 	{
@@ -3431,7 +3431,7 @@ Tango::DevVarStringArray *DataBase::db_get_device_attribute_property2(const Tang
 
 	if (all_attr == true)
 	{
-		DEBUG_STREAM << "DataBase::GetDeviceAttributeProperty2(): Get attribute properties for all attribute(s)" << endl;
+		DEBUG_STREAM << "DataBase::GetDeviceAttributeProperty2(): Get attribute properties for all attribute(s)" << std::endl;
 	}
 
 	if (all_attr == false)
@@ -3443,12 +3443,12 @@ Tango::DevVarStringArray *DataBase::db_get_device_attribute_property2(const Tang
 			sql_query_stream << "SELECT name,value FROM property_attribute_device WHERE device = \""
 		                 << tmp_device << "\" AND attribute LIKE \"" << tmp_attribute
 						 << "\" ORDER BY name,count";
-	   		DEBUG_STREAM << "DataBase::GetDeviceAttributeProperty2(): sql_query " << sql_query_stream.str() << endl;
+	   		DEBUG_STREAM << "DataBase::GetDeviceAttributeProperty2(): sql_query " << sql_query_stream.str() << std::endl;
 
 			result = query(sql_query_stream.str(),"db_get_device_attribute_property2()");
 
 	   		n_rows = mysql_num_rows(result);
-	   		DEBUG_STREAM << "DataBase::GetDeviceAttributeProperty2(): mysql_num_rows() " << n_rows << endl;
+	   		DEBUG_STREAM << "DataBase::GetDeviceAttributeProperty2(): mysql_num_rows() " << n_rows << std::endl;
 	   		n_props = n_props+2;
 	   		argout->length(n_props);
 	   		(*argout)[n_props-2] = CORBA::string_dup(tmp_attribute);
@@ -3478,7 +3478,7 @@ Tango::DevVarStringArray *DataBase::db_get_device_attribute_property2(const Tang
 							else
 								new_prop = false;
 						}
-//	            			DEBUG_STREAM << "DataBase::GetDeviceAttributeProperty2(): property[ "<< i << "] count " << row[0] << " value " << row[1] << endl;
+//	            			DEBUG_STREAM << "DataBase::GetDeviceAttributeProperty2(): property[ "<< i << "] count " << row[0] << " value " << row[1] << std::endl;
 						if (new_prop == true)
 						{
 							n_props = n_props + 3;
@@ -3520,11 +3520,11 @@ Tango::DevVarStringArray *DataBase::db_get_device_attribute_property2(const Tang
 		sql_query_stream.str("");
 		sql_query_stream << "SELECT attribute,name,value FROM property_attribute_device WHERE device = \""
 		                 << tmp_device << "\" ORDER BY attribute,name,count";
-	   	DEBUG_STREAM << "DataBase::GetDeviceAttributeProperty2(): sql_query " << sql_query_stream.str() << endl;
+	   	DEBUG_STREAM << "DataBase::GetDeviceAttributeProperty2(): sql_query " << sql_query_stream.str() << std::endl;
 
 		result = query(sql_query_stream.str(),"db_get_device_attribute_property2()");
 		n_rows = mysql_num_rows(result);
-		DEBUG_STREAM << "DataBase::GetDeviceAttributeProperty2(): mysql_num_rows() " << n_rows << endl;
+		DEBUG_STREAM << "DataBase::GetDeviceAttributeProperty2(): mysql_num_rows() " << n_rows << std::endl;
 
 		map<string,vector<PropDef> > db_data;
 
@@ -3652,7 +3652,7 @@ Tango::DevVarStringArray *DataBase::db_get_device_attribute_property2(const Tang
 		}
 	}
 
-	DEBUG_STREAM << "DataBase::GetDeviceAttributeProperty2(): argout->length() "<< argout->length() << endl;
+	DEBUG_STREAM << "DataBase::GetDeviceAttributeProperty2(): argout->length() "<< argout->length() << std::endl;
 
 	GetTime(after);
 	update_timing_stats(before, after, "DbGetDeviceAttributeProperty2");
@@ -3693,7 +3693,7 @@ Tango::DevVarStringArray *DataBase::db_get_device_attribute_property_hist(const 
 
 	if (argin->length() != 3)
 	{
-	   WARN_STREAM << "DataBase::DbGetDeviceAttributePropertyHist(): incorrect number of input arguments " << endl;
+	   WARN_STREAM << "DataBase::DbGetDeviceAttributePropertyHist(): incorrect number of input arguments " << std::endl;
 	   Tango::Except::throw_exception((const char *)DB_IncorrectArguments,
 	   				  (const char *)"incorrect no. of input arguments, needs 3 (device,attribute,property)",
 					  (const char *)"DataBase::DbGetDeviceAttributePropertyHist()");
@@ -3791,16 +3791,16 @@ Tango::DevVarStringArray *DataBase::db_get_device_class_list(Tango::DevString ar
 	GetTime(before);
 
 
-	INFO_STREAM << "DataBase::GetDeviceClassList(): server " << server << endl;
+	INFO_STREAM << "DataBase::GetDeviceClassList(): server " << server << std::endl;
 
 	sql_query_stream << "SELECT name,class FROM device WHERE server = \""
 	                 << server << "\" ORDER BY name";
-	DEBUG_STREAM << "DataBase::GetDeviceClassList(): sql_query " << sql_query_stream.str() << endl;
+	DEBUG_STREAM << "DataBase::GetDeviceClassList(): sql_query " << sql_query_stream.str() << std::endl;
 
 	result = query(sql_query_stream.str(),"db_get_device_class_list()");
 
 	n_rows = mysql_num_rows(result);
-	INFO_STREAM << "DataBase::GetDeviceClassList(): mysql_num_rows() " << n_rows << endl;
+	INFO_STREAM << "DataBase::GetDeviceClassList(): mysql_num_rows() " << n_rows << std::endl;
 	argout = new Tango::DevVarStringArray;
 
 	if (n_rows > 0)
@@ -3811,7 +3811,7 @@ Tango::DevVarStringArray *DataBase::db_get_device_class_list(Tango::DevString ar
 	   {
 	      if ((row = mysql_fetch_row(result)) != NULL)
 	      {
-	         DEBUG_STREAM << "DataBase::GetDeviceClassList(): row[ "<< i << "] name " << row[0] << " class " << row[1] << endl;
+	         DEBUG_STREAM << "DataBase::GetDeviceClassList(): row[ "<< i << "] name " << row[0] << " class " << row[1] << std::endl;
 	         (*argout)[i*2]   = CORBA::string_dup(row[0]);
 	         (*argout)[i*2+1] = CORBA::string_dup(row[1]);
 	      }
@@ -3853,7 +3853,7 @@ Tango::DevVarStringArray *DataBase::db_get_device_domain_list(Tango::DevString a
 	TimeVal	before, after;
 	GetTime(before);
 
-	INFO_STREAM << "DataBase::db_get_device_domain_list(): wild card " << wildcard << endl;
+	INFO_STREAM << "DataBase::db_get_device_domain_list(): wild card " << wildcard << std::endl;
 
 	if (wildcard == NULL)
 	{
@@ -3866,12 +3866,12 @@ Tango::DevVarStringArray *DataBase::db_get_device_domain_list(Tango::DevString a
 		                 << tmp_wildcard << "\" OR alias LIKE \"" << tmp_wildcard
 						 << "\" ORDER BY domain";
 	}
-	DEBUG_STREAM << "DataBase::db_get_device_domain_list(): sql_query " << sql_query_stream.str() << endl;
+	DEBUG_STREAM << "DataBase::db_get_device_domain_list(): sql_query " << sql_query_stream.str() << std::endl;
 
 	result = query(sql_query_stream.str(),"db_get_device_domain_list()");
 
 	n_rows = mysql_num_rows(result);
-	DEBUG_STREAM << "DataBase::db_get_device_domain_list(): mysql_num_rows() " << n_rows << endl;
+	DEBUG_STREAM << "DataBase::db_get_device_domain_list(): mysql_num_rows() " << n_rows << std::endl;
 	argout = new Tango::DevVarStringArray;
 
 	if (n_rows > 0)
@@ -3881,7 +3881,7 @@ Tango::DevVarStringArray *DataBase::db_get_device_domain_list(Tango::DevString a
 	   {
 	      if ((row = mysql_fetch_row(result)) != NULL)
 	      {
-//	         DEBUG_STREAM << "DataBase::db_get_device_domain_list(): domain[ "<< i << "] " << row[0] << endl;
+//	         DEBUG_STREAM << "DataBase::db_get_device_domain_list(): domain[ "<< i << "] " << row[0] << std::endl;
 	         (*argout)[i] = CORBA::string_dup(row[0]);
 	      }
 	   }
@@ -3922,7 +3922,7 @@ Tango::DevVarStringArray *DataBase::db_get_device_exported_list(Tango::DevString
 	TimeVal	before, after;
 	GetTime(before);
 
-	INFO_STREAM << "DataBase::db_get_device_exported_list(): filter " << filter << endl;
+	INFO_STREAM << "DataBase::db_get_device_exported_list(): filter " << filter << std::endl;
 
 	if (filter == NULL)
 	{
@@ -3935,12 +3935,12 @@ Tango::DevVarStringArray *DataBase::db_get_device_exported_list(Tango::DevString
 		                 << tmp_filter << "\" OR alias LIKE \"" << tmp_filter
 						 << "\") AND exported=1 ORDER BY name";
 	}
-	DEBUG_STREAM << "DataBase::db_get_device_exported_list(): sql_query " << sql_query_stream.str() << endl;
+	DEBUG_STREAM << "DataBase::db_get_device_exported_list(): sql_query " << sql_query_stream.str() << std::endl;
 
 	result = query(sql_query_stream.str(),"db_get_device_exported_list()");
 
 	n_rows = mysql_num_rows(result);
-	DEBUG_STREAM << "DataBase::db_get_device_exported_list(): mysql_num_rows() " << n_rows << endl;
+	DEBUG_STREAM << "DataBase::db_get_device_exported_list(): mysql_num_rows() " << n_rows << std::endl;
 	argout = new Tango::DevVarStringArray;
 
 	if (n_rows > 0)
@@ -3951,7 +3951,7 @@ Tango::DevVarStringArray *DataBase::db_get_device_exported_list(Tango::DevString
 	   {
 	      if ((row = mysql_fetch_row(result)) != NULL)
 	      {
-	         DEBUG_STREAM << "DataBase::db_get_device_exported_list(): device_list[ "<< i << "] alias " << row[0] << endl;
+	         DEBUG_STREAM << "DataBase::db_get_device_exported_list(): device_list[ "<< i << "] alias " << row[0] << std::endl;
 	         (*argout)[i]   = CORBA::string_dup(row[0]);
 	      }
 	   }
@@ -3994,7 +3994,7 @@ Tango::DevVarStringArray *DataBase::db_get_device_family_list(Tango::DevString a
 	GetTime(before);
 
 
-	INFO_STREAM << "DataBase::db_get_device_family_list(): wild card " << wildcard << endl;
+	INFO_STREAM << "DataBase::db_get_device_family_list(): wild card " << wildcard << std::endl;
 
 	if (wildcard == NULL)
 	{
@@ -4007,12 +4007,12 @@ Tango::DevVarStringArray *DataBase::db_get_device_family_list(Tango::DevString a
 		                 << tmp_wildcard << "\" OR alias LIKE \"" << tmp_wildcard
 						 << "\" ORDER BY family";
 	}
-	DEBUG_STREAM << "DataBase::db_get_device_family_list(): sql_query " << sql_query_stream.str() << endl;
+	DEBUG_STREAM << "DataBase::db_get_device_family_list(): sql_query " << sql_query_stream.str() << std::endl;
 
 	result = query(sql_query_stream.str(),"db_get_device_family_list()");
 
 	n_rows = mysql_num_rows(result);
-	DEBUG_STREAM << "DataBase::db_get_device_family_list(): mysql_num_rows() " << n_rows << endl;
+	DEBUG_STREAM << "DataBase::db_get_device_family_list(): mysql_num_rows() " << n_rows << std::endl;
 	argout = new Tango::DevVarStringArray;
 
 	if (n_rows > 0)
@@ -4022,7 +4022,7 @@ Tango::DevVarStringArray *DataBase::db_get_device_family_list(Tango::DevString a
 	   {
 	      if ((row = mysql_fetch_row(result)) != NULL)
 	      {
-	         DEBUG_STREAM << "DataBase::db_get_device_family_list(): family[ "<< i << "] " << row[0] << endl;
+	         DEBUG_STREAM << "DataBase::db_get_device_family_list(): family[ "<< i << "] " << row[0] << std::endl;
 	         (*argout)[i] = CORBA::string_dup(row[0]);
 	      }
 	   }
@@ -4070,7 +4070,7 @@ Tango::DevVarLongStringArray *DataBase::db_get_device_info(Tango::DevString argi
 	int exported, pid;
 	string tmp_device;
 
-	INFO_STREAM << "DataBase::ImportDevice(): get import info for " << argin << " device " << endl;
+	INFO_STREAM << "DataBase::ImportDevice(): get import info for " << argin << " device " << std::endl;
 
 	tmp_device = argin;
 	for (unsigned int i=0; i<tmp_device.size(); i++) {
@@ -4079,12 +4079,12 @@ Tango::DevVarLongStringArray *DataBase::db_get_device_info(Tango::DevString argi
 
 	sql_query_stream << "SELECT exported,ior,version,pid,server,host,started,stopped,class FROM device WHERE name = '"
 	                 << tmp_device << "' or alias = '" << tmp_device << "';";
-	DEBUG_STREAM << "DataBase::ImportDevice(): sql_query " << sql_query_stream.str() << endl;
+	DEBUG_STREAM << "DataBase::ImportDevice(): sql_query " << sql_query_stream.str() << std::endl;
 
 	result = query(sql_query_stream.str(),"db_get_device_info()");
 
 	n_rows = mysql_num_rows(result);
-	DEBUG_STREAM << "DataBase::ImportDeviceList(): mysql_num_rows() " << n_rows << endl;
+	DEBUG_STREAM << "DataBase::ImportDeviceList(): mysql_num_rows() " << n_rows << std::endl;
 
 	argout = new Tango::DevVarLongStringArray;
 	if (n_rows > 0)
@@ -4092,14 +4092,14 @@ Tango::DevVarLongStringArray *DataBase::db_get_device_info(Tango::DevString argi
 
 	   if ((row = mysql_fetch_row(result)) != NULL)
 	   {
-	      DEBUG_STREAM << "DataBase::ImportDeviceList():  exported " << row[0] << " version " << row[2] << " server " << row[4] << " host " << row[5] << endl;
+	      DEBUG_STREAM << "DataBase::ImportDeviceList():  exported " << row[0] << " version " << row[2] << " server " << row[4] << " host " << row[5] << std::endl;
 	   	  int n_svalues=0, n_lvalues=0;
 	      n_svalues = 8;
 		  if ((row[4] == NULL) || (row[5] == NULL))
 		  {
 	         TangoSys_OMemStream o;
 			 o << "Wrong info in database for device " << tmp_device;
-			 o << "Database entry seems corrupted (server or host column NULL)" << ends;
+			 o << "Database entry seems corrupted (server or host column NULL)" << std::ends;
 	    	 mysql_free_result(result);
 			 delete argout;
 	    	 Tango::Except::throw_exception((const char *)DB_DeviceNotDefined,
@@ -4158,7 +4158,7 @@ Tango::DevVarLongStringArray *DataBase::db_get_device_info(Tango::DevString argi
 	      (argout->lvalue)[n_lvalues-1] = pid;
 	   }
 		else {
-	    	 INFO_STREAM << "DataBase::ImportDevice(): info not defined !" << endl;
+	    	 INFO_STREAM << "DataBase::ImportDevice(): info not defined !" << std::endl;
 	         TangoSys_OMemStream o;
 			 o << "device " << tmp_device << " import info not found in the database !";
 	    	 mysql_free_result(result);
@@ -4169,7 +4169,7 @@ Tango::DevVarLongStringArray *DataBase::db_get_device_info(Tango::DevString argi
 		}
 	}
 	else {
-	     INFO_STREAM << "DataBase::ImportDevice(): device not defined !" << endl;
+	     INFO_STREAM << "DataBase::ImportDevice(): device not defined !" << std::endl;
          TangoSys_OMemStream o;
 		 o << "device " << tmp_device << " not defined in the database !";
 	     mysql_free_result(result);
@@ -4210,7 +4210,7 @@ Tango::DevVarStringArray *DataBase::db_get_device_list(const Tango::DevVarString
 
 	if (server_class->length() != 2)
 	{
-	   WARN_STREAM << "DataBase::db_get_device_list(): incorrect number of input arguments " << endl;
+	   WARN_STREAM << "DataBase::db_get_device_list(): incorrect number of input arguments " << std::endl;
 	   Tango::Except::throw_exception((const char *)DB_IncorrectArguments,
 	   				  (const char *)"incorrect no. of input arguments, needs 2 (server,class)",
 					  (const char *)"DataBase::GetDeviceList()");
@@ -4219,16 +4219,16 @@ Tango::DevVarStringArray *DataBase::db_get_device_list(const Tango::DevVarString
 	tmp_server = replace_wildcard((*server_class)[0]);
 	tmp_class = replace_wildcard((*server_class)[1]);
 
-	INFO_STREAM << "DataBase::GetClassList(): server " << tmp_server << endl;
+	INFO_STREAM << "DataBase::GetClassList(): server " << tmp_server << std::endl;
 
 	sql_query_stream << "SELECT DISTINCT name FROM device WHERE server LIKE \""
 	                 << tmp_server << "\" AND class LIKE \"" << tmp_class << "\" ORDER BY name";
-	DEBUG_STREAM << "DataBase::GetDeviceList(): sql_query " << sql_query_stream.str() << endl;
+	DEBUG_STREAM << "DataBase::GetDeviceList(): sql_query " << sql_query_stream.str() << std::endl;
 
 	result = query(sql_query_stream.str(),"db_get_device_list()");
 
 	n_rows = mysql_num_rows(result);
-	DEBUG_STREAM << "DataBase::GetDeviceList(): mysql_num_rows() " << n_rows << endl;
+	DEBUG_STREAM << "DataBase::GetDeviceList(): mysql_num_rows() " << n_rows << std::endl;
 	argout = new Tango::DevVarStringArray;
 
 	if (n_rows > 0)
@@ -4239,7 +4239,7 @@ Tango::DevVarStringArray *DataBase::db_get_device_list(const Tango::DevVarString
 	   {
 	      if ((row = mysql_fetch_row(result)) != NULL)
 	      {
-	         DEBUG_STREAM << "DataBase::GetdeviceList(): row[ "<< i << "] name " << row[0] << endl;
+	         DEBUG_STREAM << "DataBase::GetdeviceList(): row[ "<< i << "] name " << row[0] << std::endl;
 	         (*argout)[i]   = CORBA::string_dup(row[0]);
 	      }
 	   }
@@ -4277,7 +4277,7 @@ Tango::DevVarStringArray *DataBase::db_get_device_wide_list(Tango::DevString arg
 	TimeVal	before, after;
 	GetTime(before);
 
-	INFO_STREAM << "DataBase::db_get_device_wide_list(): filter " << filter << endl;
+	INFO_STREAM << "DataBase::db_get_device_wide_list(): filter " << filter << std::endl;
 
 	if (filter == NULL)
 	{
@@ -4289,12 +4289,12 @@ Tango::DevVarStringArray *DataBase::db_get_device_wide_list(Tango::DevString arg
 		sql_query_stream << "SELECT DISTINCT name FROM device WHERE name LIKE \""
 		                 << tmp_filter << "\"  ORDER BY name";
 	}
-	DEBUG_STREAM << "DataBase::db_get_device_wide_list(): sql_query " << sql_query_stream.str() << endl;
+	DEBUG_STREAM << "DataBase::db_get_device_wide_list(): sql_query " << sql_query_stream.str() << std::endl;
 
 	result = query(sql_query_stream.str(),"db_get_device_wide_list()");
 
 	n_rows = mysql_num_rows(result);
-	DEBUG_STREAM << "DataBase::db_get_device_wide_list(): mysql_num_rows() " << n_rows << endl;
+	DEBUG_STREAM << "DataBase::db_get_device_wide_list(): mysql_num_rows() " << n_rows << std::endl;
 	argout = new Tango::DevVarStringArray;
 
 	if (n_rows > 0)
@@ -4305,7 +4305,7 @@ Tango::DevVarStringArray *DataBase::db_get_device_wide_list(Tango::DevString arg
 	   {
 	      if ((row = mysql_fetch_row(result)) != NULL)
 	      {
-	         DEBUG_STREAM << "DataBase::db_get_device_wide_list(): device_list[ "<< i << "] alias " << row[0] << endl;
+	         DEBUG_STREAM << "DataBase::db_get_device_wide_list(): device_list[ "<< i << "] alias " << row[0] << std::endl;
 	         (*argout)[i]   = CORBA::string_dup(row[0]);
 	      }
 	   }
@@ -4347,7 +4347,7 @@ Tango::DevVarStringArray *DataBase::db_get_device_member_list(Tango::DevString a
 	GetTime(before);
 
 
-	INFO_STREAM << "DataBase::db_get_device_member_list(): wild card " << wildcard << endl;
+	INFO_STREAM << "DataBase::db_get_device_member_list(): wild card " << wildcard << std::endl;
 
 	if (wildcard == NULL)
 	{
@@ -4360,12 +4360,12 @@ Tango::DevVarStringArray *DataBase::db_get_device_member_list(Tango::DevString a
 		                 << tmp_wildcard << "\" OR alias LIKE \"" << tmp_wildcard
 						 << "\" ORDER BY member";
 	}
-	DEBUG_STREAM << "DataBase::db_get_device_member_list(): sql_query " << sql_query_stream.str() << endl;
+	DEBUG_STREAM << "DataBase::db_get_device_member_list(): sql_query " << sql_query_stream.str() << std::endl;
 
 	result = query(sql_query_stream.str(),"db_get_device_member_list()");
 
 	n_rows = mysql_num_rows(result);
-	DEBUG_STREAM << "DataBase::db_get_device_member_list(): mysql_num_rows() " << n_rows << endl;
+	DEBUG_STREAM << "DataBase::db_get_device_member_list(): mysql_num_rows() " << n_rows << std::endl;
 	argout = new Tango::DevVarStringArray;
 
 	if (n_rows > 0)
@@ -4375,7 +4375,7 @@ Tango::DevVarStringArray *DataBase::db_get_device_member_list(Tango::DevString a
 	   {
 	      if ((row = mysql_fetch_row(result)) != NULL)
 	      {
-	         DEBUG_STREAM << "DataBase::db_get_device_member_list(): member[ "<< i << "] " << row[0] << endl;
+	         DEBUG_STREAM << "DataBase::db_get_device_member_list(): member[ "<< i << "] " << row[0] << std::endl;
 	         (*argout)[i] = CORBA::string_dup(row[0]);
 	      }
 	   }
@@ -4433,13 +4433,13 @@ Tango::DevVarStringArray *DataBase::db_get_device_property(const Tango::DevVarSt
 
 	if (property_names->length() < 2)
 	{
-	   WARN_STREAM << "DataBase::GetDeviceProperty(): incorrect number of input arguments " << endl;
+	   WARN_STREAM << "DataBase::GetDeviceProperty(): incorrect number of input arguments " << std::endl;
 	   Tango::Except::throw_exception((const char *)DB_IncorrectArguments,
 	   				  (const char *)"incorrect no. of input arguments, needs at least 2 (device,property)",
 					  (const char *)"DataBase::GetDeviceProperty()");
 	}
 
-	INFO_STREAM << "DataBase::GetDeviceProperty(): get " << property_names->length()-1 << " properties for device " << (*property_names)[0] << endl;
+	INFO_STREAM << "DataBase::GetDeviceProperty(): get " << property_names->length()-1 << " properties for device " << (*property_names)[0] << std::endl;
 
 	argout = new Tango::DevVarStringArray;
 
@@ -4461,12 +4461,12 @@ Tango::DevVarStringArray *DataBase::db_get_device_property(const Tango::DevVarSt
 	   sql_query_stream.str("");
 	   sql_query_stream << "SELECT count,value,name FROM property_device WHERE device = \""
 	                    << tmp_device << "\" AND name LIKE \"" << tmp_name << "\" ORDER BY count";
-	   DEBUG_STREAM << "DataBase::GetDeviceProperty(): sql_query " << sql_query_stream.str() << endl;
+	   DEBUG_STREAM << "DataBase::GetDeviceProperty(): sql_query " << sql_query_stream.str() << std::endl;
 
 	   result = query(sql_query_stream.str(),"db_get_device_property()");
 
 	   n_rows = mysql_num_rows(result);
-	   DEBUG_STREAM << "DataBase::GetDeviceProperty(): mysql_num_rows() " << n_rows << endl;
+	   DEBUG_STREAM << "DataBase::GetDeviceProperty(): mysql_num_rows() " << n_rows << std::endl;
 	   sprintf(n_rows_str,"%d",n_rows);
 	   n_props = n_props+2;
 	   argout->length(n_props);
@@ -4479,7 +4479,7 @@ Tango::DevVarStringArray *DataBase::db_get_device_property(const Tango::DevVarSt
 	      {
 	         if ((row = mysql_fetch_row(result)) != NULL)
 	         {
-	            DEBUG_STREAM << "DataBase::GetDeviceProperty(): property[ "<< i << "] count " << row[0] << " value " << row[1] << endl;
+	            DEBUG_STREAM << "DataBase::GetDeviceProperty(): property[ "<< i << "] count " << row[0] << " value " << row[1] << std::endl;
 		    	n_props++;
 		    	argout->length(n_props);
 	            (*argout)[n_props-1] = CORBA::string_dup(row[1]);
@@ -4495,7 +4495,7 @@ Tango::DevVarStringArray *DataBase::db_get_device_property(const Tango::DevVarSt
 	   mysql_free_result(result);
 	}
 
-	DEBUG_STREAM << "DataBase::GetDeviceProperty(): argout->length() "<< argout->length() << endl;
+	DEBUG_STREAM << "DataBase::GetDeviceProperty(): argout->length() "<< argout->length() << std::endl;
 
 	GetTime(after);
 	update_timing_stats(before, after, "DbGetDeviceProperty");
@@ -4533,7 +4533,7 @@ Tango::DevVarStringArray *DataBase::db_get_device_property_hist(const Tango::Dev
 
 	if (argin->length() != 2)
 	{
-	   WARN_STREAM << "DataBase::GetDevicePropertyHist(): incorrect number of input arguments " << endl;
+	   WARN_STREAM << "DataBase::GetDevicePropertyHist(): incorrect number of input arguments " << std::endl;
 	   Tango::Except::throw_exception((const char *)DB_IncorrectArguments,
 	   				  (const char *)"incorrect no. of input arguments, needs 2 (device,property)",
 					  (const char *)"DataBase::GetDevicePropertyHist()");
@@ -4632,7 +4632,7 @@ Tango::DevVarStringArray *DataBase::db_get_device_property_list(const Tango::Dev
 	device = (*device_wildcard)[0];
 	wildcard = (*device_wildcard)[1];
 	INFO_STREAM << "DataBase::db_get_device_property_list(): device " << device ;
-	INFO_STREAM << " wildcard " << wildcard << endl;
+	INFO_STREAM << " wildcard " << wildcard << std::endl;
 
 	if (wildcard == NULL)
 	{
@@ -4645,12 +4645,12 @@ Tango::DevVarStringArray *DataBase::db_get_device_property_list(const Tango::Dev
 		sql_query_stream << "SELECT name FROM property_device WHERE device=\"" << device
 		                 << "\" AND name LIKE \"" << tmp_wildcard << "\" AND count=1 ORDER BY name";
 	}
-	DEBUG_STREAM << "DataBase::db_get_device_property_list(): sql_query " << sql_query_stream.str() << endl;
+	DEBUG_STREAM << "DataBase::db_get_device_property_list(): sql_query " << sql_query_stream.str() << std::endl;
 
 	result = query(sql_query_stream.str(),"db_get_device_property_list()");
 
 	n_rows = mysql_num_rows(result);
-	DEBUG_STREAM << "DataBase::db_get_device_property_list(): mysql_num_rows() " << n_rows << endl;
+	DEBUG_STREAM << "DataBase::db_get_device_property_list(): mysql_num_rows() " << n_rows << std::endl;
 	argout = new Tango::DevVarStringArray;
 
 	if (n_rows > 0)
@@ -4661,7 +4661,7 @@ Tango::DevVarStringArray *DataBase::db_get_device_property_list(const Tango::Dev
 	   {
 	      if ((row = mysql_fetch_row(result)) != NULL)
 	      {
-	         DEBUG_STREAM << "DataBase::db_get_device_property_list(): property[ "<< i << "] alias " << row[0] << endl;
+	         DEBUG_STREAM << "DataBase::db_get_device_property_list(): property[ "<< i << "] alias " << row[0] << std::endl;
 	         (*argout)[i]   = CORBA::string_dup(row[0]);
 	      }
 	   }
@@ -4699,17 +4699,17 @@ Tango::DevVarStringArray *DataBase::db_get_device_server_class_list(Tango::DevSt
 	int n_rows;
 	string tmp_server;
 
-	INFO_STREAM << "DataBase::db_get_device_server_class_list(): server " << server << endl;
+	INFO_STREAM << "DataBase::db_get_device_server_class_list(): server " << server << std::endl;
 
 	tmp_server = replace_wildcard(server);
 	sql_query_stream << "SELECT DISTINCT class FROM device WHERE server LIKE \"" << tmp_server
 	                 << "\" ORDER BY class";
-	DEBUG_STREAM << "DataBase::db_get_device_server_class_list(): sql_query " << sql_query_stream.str() << endl;
+	DEBUG_STREAM << "DataBase::db_get_device_server_class_list(): sql_query " << sql_query_stream.str() << std::endl;
 
 	result = query(sql_query_stream.str(),"db_get_device_server_class_list()");
 
 	n_rows = mysql_num_rows(result);
-	DEBUG_STREAM << "DataBase::db_get_device_server_class_list(): mysql_num_rows() " << n_rows << endl;
+	DEBUG_STREAM << "DataBase::db_get_device_server_class_list(): mysql_num_rows() " << n_rows << std::endl;
 	argout = new Tango::DevVarStringArray;
 
 	if (n_rows > 0)
@@ -4720,7 +4720,7 @@ Tango::DevVarStringArray *DataBase::db_get_device_server_class_list(Tango::DevSt
 	   {
 	      if ((row = mysql_fetch_row(result)) != NULL)
 	      {
-	         DEBUG_STREAM << "DataBase::db_get_device_server_class_list(): row[ "<< i << "] class " << row[0] << endl;
+	         DEBUG_STREAM << "DataBase::db_get_device_server_class_list(): row[ "<< i << "] class " << row[0] << std::endl;
 	         (*argout)[i]   = CORBA::string_dup(row[0]);
 	      }
 	   }
@@ -4755,7 +4755,7 @@ Tango::DevVarStringArray *DataBase::db_get_exportd_device_list_for_class(Tango::
 	MYSQL_ROW row;
 	int n_rows;
 
-	INFO_STREAM << "DataBase::db_get_device_exported_list(): classname " << classname << endl;
+	INFO_STREAM << "DataBase::db_get_device_exported_list(): classname " << classname << std::endl;
 
 	if (classname == NULL)
 	{
@@ -4767,12 +4767,12 @@ Tango::DevVarStringArray *DataBase::db_get_exportd_device_list_for_class(Tango::
 		sql_query_stream << "SELECT DISTINCT name FROM device WHERE class LIKE \"" << tmp_classname
 		                 << "\" AND exported=1 ORDER BY name";
 	}
-	DEBUG_STREAM << "DataBase::db_get_device_exported_list(): sql_query " << sql_query_stream.str() << endl;
+	DEBUG_STREAM << "DataBase::db_get_device_exported_list(): sql_query " << sql_query_stream.str() << std::endl;
 
 	result = query(sql_query_stream.str(),"db_get_exportd_device_list_for_class()");
 
 	n_rows = mysql_num_rows(result);
-	DEBUG_STREAM << "DataBase::db_get_device_exported_list(): mysql_num_rows() " << n_rows << endl;
+	DEBUG_STREAM << "DataBase::db_get_device_exported_list(): mysql_num_rows() " << n_rows << std::endl;
 	argout = new Tango::DevVarStringArray;
 
 	if (n_rows > 0)
@@ -4783,7 +4783,7 @@ Tango::DevVarStringArray *DataBase::db_get_exportd_device_list_for_class(Tango::
 	   {
 	      if ((row = mysql_fetch_row(result)) != NULL)
 	      {
-	         DEBUG_STREAM << "DataBase::db_get_device_exported_list(): device_list[ "<< i << "] alias " << row[0] << endl;
+	         DEBUG_STREAM << "DataBase::db_get_device_exported_list(): device_list[ "<< i << "] alias " << row[0] << std::endl;
 	         (*argout)[i]   = CORBA::string_dup(row[0]);
 	      }
 	   }
@@ -4822,7 +4822,7 @@ Tango::DevVarStringArray *DataBase::db_get_host_list(Tango::DevString argin)
 	GetTime(before);
 
 
-	INFO_STREAM << "DataBase::db_get_host_list(): wild card " << wildcard << endl;
+	INFO_STREAM << "DataBase::db_get_host_list(): wild card " << wildcard << std::endl;
 
 	if (wildcard == NULL)
 	{
@@ -4834,12 +4834,12 @@ Tango::DevVarStringArray *DataBase::db_get_host_list(Tango::DevString argin)
 		sql_query_stream << "SELECT DISTINCT host FROM device WHERE host LIKE \"" << tmp_wildcard
 		                 << "\" ORDER BY host";
 	}
-	DEBUG_STREAM << "DataBase::db_get_host_list(): sql_query " << sql_query_stream.str() << endl;
+	DEBUG_STREAM << "DataBase::db_get_host_list(): sql_query " << sql_query_stream.str() << std::endl;
 
 	result = query(sql_query_stream.str(),"db_get_host_list()");
 
 	n_rows = mysql_num_rows(result);
-	DEBUG_STREAM << "DataBase::db_get_host_list(): mysql_num_rows() " << n_rows << endl;
+	DEBUG_STREAM << "DataBase::db_get_host_list(): mysql_num_rows() " << n_rows << std::endl;
 	argout = new Tango::DevVarStringArray;
 
 	if (n_rows > 0)
@@ -4850,7 +4850,7 @@ Tango::DevVarStringArray *DataBase::db_get_host_list(Tango::DevString argin)
 	   {
 	      if ((row = mysql_fetch_row(result)) != NULL)
 	      {
-	         DEBUG_STREAM << "DataBase::db_get_host_list(): host[ "<< i << "] alias " << row[0] << endl;
+	         DEBUG_STREAM << "DataBase::db_get_host_list(): host[ "<< i << "] alias " << row[0] << std::endl;
 	         (*argout)[i]   = CORBA::string_dup(row[0]);
 	      }
 	   }
@@ -4892,7 +4892,7 @@ Tango::DevVarStringArray *DataBase::db_get_host_server_list(Tango::DevString arg
 	TimeVal	before, after;
 	GetTime(before);
 
-	INFO_STREAM << "DataBase::db_get_host_server_list(): wild card " << wildcard << endl;
+	INFO_STREAM << "DataBase::db_get_host_server_list(): wild card " << wildcard << std::endl;
 
 	if (wildcard == NULL)
 	{
@@ -4906,12 +4906,12 @@ Tango::DevVarStringArray *DataBase::db_get_host_server_list(Tango::DevString arg
 		sql_query_stream << "SELECT DISTINCT server FROM device WHERE (host LIKE \"" << tmp_wildcard
 		                 << "\" or host LIKE \"" << tmp_wildcard << ".%%\") AND name LIKE \"dserver/%%\" ORDER BY server";
 	}
-	DEBUG_STREAM << "DataBase::db_get_host_server_list(): sql_query " << sql_query_stream.str() << endl;
+	DEBUG_STREAM << "DataBase::db_get_host_server_list(): sql_query " << sql_query_stream.str() << std::endl;
 
 	result = query(sql_query_stream.str(),"db_get_host_server_list()");
 
 	n_rows = mysql_num_rows(result);
-	DEBUG_STREAM << "DataBase::db_get_host_server_list(): mysql_num_rows() " << n_rows << endl;
+	DEBUG_STREAM << "DataBase::db_get_host_server_list(): mysql_num_rows() " << n_rows << std::endl;
 	argout = new Tango::DevVarStringArray;
 
 	if (n_rows > 0)
@@ -4922,7 +4922,7 @@ Tango::DevVarStringArray *DataBase::db_get_host_server_list(Tango::DevString arg
 	   {
 	      if ((row = mysql_fetch_row(result)) != NULL)
 	      {
-	         DEBUG_STREAM << "DataBase::db_get_host_server_list(): row[ "<< i << "] alias " << row[0] << endl;
+	         DEBUG_STREAM << "DataBase::db_get_host_server_list(): row[ "<< i << "] alias " << row[0] << std::endl;
 	         (*argout)[i]   = CORBA::string_dup(row[0]);
 	      }
 	   }
@@ -4955,7 +4955,7 @@ Tango::DevVarStringArray *DataBase::db_get_host_servers_info(Tango::DevString ar
 	//	Add your own code
 	//- struct timeval	t0, t;
 	//- gettimeofday(&t0, NULL);
-	INFO_STREAM << "DataBase::db_get_host_servers_info(): entering... !" << endl;
+	INFO_STREAM << "DataBase::db_get_host_servers_info(): entering... !" << std::endl;
 	//	Get server list
 	Tango::DevVarStringArray	*servers = db_get_host_server_list(argin);
 	argout  = new Tango::DevVarStringArray();
@@ -4975,7 +4975,7 @@ Tango::DevVarStringArray *DataBase::db_get_host_servers_info(Tango::DevString ar
 	//	Check execution duration
 	//- gettimeofday(&t, NULL);
 	//- WARN_STREAM << argin << "; " << 1000.0*(t.tv_sec - t0.tv_sec) +
-	//-	((double)t.tv_usec - t0.tv_usec) / 1000 << " ms" << endl;
+	//-	((double)t.tv_usec - t0.tv_usec) / 1000 << " ms" << std::endl;
 
 	/*----- PROTECTED REGION END -----*/	//	DataBase::db_get_host_servers_info
 	return argout;
@@ -5053,18 +5053,18 @@ Tango::DevVarStringArray *DataBase::db_get_object_list(Tango::DevString argin)
 	int n_rows;
 	string tmp_wildcard;
 
-	INFO_STREAM << "DataBase::db_get_object_list(): object " << wildcard << endl;
+	INFO_STREAM << "DataBase::db_get_object_list(): object " << wildcard << std::endl;
 
 	tmp_wildcard = replace_wildcard(wildcard);
 	sql_query_stream << "SELECT DISTINCT object FROM property WHERE object LIKE \""
 	                 << tmp_wildcard << "\" ORDER BY object";
 
-	DEBUG_STREAM << "DataBase::db_get_object_list(): sql_query " << sql_query_stream.str() << endl;
+	DEBUG_STREAM << "DataBase::db_get_object_list(): sql_query " << sql_query_stream.str() << std::endl;
 
 	result = query(sql_query_stream.str(),"db_get_object_list()");
 
 	n_rows = mysql_num_rows(result);
-	DEBUG_STREAM << "DataBase::db_get_object_list(): mysql_num_rows() " << n_rows << endl;
+	DEBUG_STREAM << "DataBase::db_get_object_list(): mysql_num_rows() " << n_rows << std::endl;
 	argout = new Tango::DevVarStringArray;
 
 	if (n_rows > 0)
@@ -5075,7 +5075,7 @@ Tango::DevVarStringArray *DataBase::db_get_object_list(Tango::DevString argin)
 	   {
 	      if ((row = mysql_fetch_row(result)) != NULL)
 	      {
-//	         DEBUG_STREAM << "DataBase::db_get_object_list(): object[ "<< i << "] object " << row[0] << endl;
+//	         DEBUG_STREAM << "DataBase::db_get_object_list(): object[ "<< i << "] object " << row[0] << std::endl;
 	         (*argout)[i]   = CORBA::string_dup(row[0]);
 	      }
 	   }
@@ -5125,7 +5125,7 @@ Tango::DevVarStringArray *DataBase::db_get_property(const Tango::DevVarStringArr
 	const char *tmp_object;
 	string tmp_name;
 
-	INFO_STREAM << "DataBase::db_get_property(): get " << property_names->length()-1 << " properties for object " << (*property_names)[0] << endl;
+	INFO_STREAM << "DataBase::db_get_property(): get " << property_names->length()-1 << " properties for object " << (*property_names)[0] << std::endl;
 
 	tmp_object = (*property_names)[0];
 #ifdef TANGO_LONG32
@@ -5144,12 +5144,12 @@ Tango::DevVarStringArray *DataBase::db_get_property(const Tango::DevVarStringArr
 	   sql_query_stream.str("");
 	   sql_query_stream << "SELECT count,value,name FROM property WHERE object = \"" << tmp_object <<
 	                       "\" AND name LIKE \"" << tmp_name << "\" ORDER BY count";
-	   DEBUG_STREAM << "DataBase::db_get_property(): sql_query " << sql_query_stream.str() << endl;
+	   DEBUG_STREAM << "DataBase::db_get_property(): sql_query " << sql_query_stream.str() << std::endl;
 
 	   result = query(sql_query_stream.str(),"db_get_property()");
 
 	   n_rows = mysql_num_rows(result);
-	   DEBUG_STREAM << "DataBase::db_get_property(): mysql_num_rows() " << n_rows << endl;
+	   DEBUG_STREAM << "DataBase::db_get_property(): mysql_num_rows() " << n_rows << std::endl;
 	   sprintf(n_rows_str,"%d",n_rows);
 	   n_props = n_props+2;
 	   argout->length(n_props);
@@ -5161,7 +5161,7 @@ Tango::DevVarStringArray *DataBase::db_get_property(const Tango::DevVarStringArr
 	      {
 	         if ((row = mysql_fetch_row(result)) != NULL)
 	         {
-	            DEBUG_STREAM << "DataBase::db_get_property(): property[ "<< i << "] count " << row[0] << " value " << row[1] << endl;
+	            DEBUG_STREAM << "DataBase::db_get_property(): property[ "<< i << "] count " << row[0] << " value " << row[1] << std::endl;
 		    	n_props++;
 	   	    	argout->length(n_props);
 	            (*argout)[n_props-1] = CORBA::string_dup(row[1]);
@@ -5177,7 +5177,7 @@ Tango::DevVarStringArray *DataBase::db_get_property(const Tango::DevVarStringArr
 	   mysql_free_result(result);
 	}
 
-	DEBUG_STREAM << "DataBase::db_get_property(): argout->length() "<< argout->length() << endl;
+	DEBUG_STREAM << "DataBase::db_get_property(): argout->length() "<< argout->length() << std::endl;
 
 	/*----- PROTECTED REGION END -----*/	//	DataBase::db_get_property
 	return argout;
@@ -5212,7 +5212,7 @@ Tango::DevVarStringArray *DataBase::db_get_property_hist(const Tango::DevVarStri
 
 	if (argin->length() != 2)
 	{
-	   WARN_STREAM << "DataBase::DbGetPropertyHist(): incorrect number of input arguments " << endl;
+	   WARN_STREAM << "DataBase::DbGetPropertyHist(): incorrect number of input arguments " << std::endl;
 	   Tango::Except::throw_exception((const char *)DB_IncorrectArguments,
 	   				  (const char *)"incorrect no. of input arguments, needs 2 (object,property)",
 					  (const char *)"DataBase::DbGetPropertyHist()");
@@ -5306,7 +5306,7 @@ Tango::DevVarStringArray *DataBase::db_get_property_list(const Tango::DevVarStri
 
 	if (object_wildcard->length() != 2)
 	{
-	   WARN_STREAM << "DataBase::db_get_property_list(): incorrect number of input arguments " << endl;
+	   WARN_STREAM << "DataBase::db_get_property_list(): incorrect number of input arguments " << std::endl;
 	   Tango::Except::throw_exception((const char *)DB_IncorrectArguments,
 	   				  (const char *)"incorrect no. of input arguments, needs 2 (object,wildcard)",
 					  (const char *)"DataBase::GetPropertyList()");
@@ -5314,7 +5314,7 @@ Tango::DevVarStringArray *DataBase::db_get_property_list(const Tango::DevVarStri
 	object = (*object_wildcard)[0];
 	wildcard = (*object_wildcard)[1];
 
-	INFO_STREAM << "DataBase::db_get_property_list(): object " << object << endl;
+	INFO_STREAM << "DataBase::db_get_property_list(): object " << object << std::endl;
 
 	if (object == NULL)
 	{
@@ -5326,12 +5326,12 @@ Tango::DevVarStringArray *DataBase::db_get_property_list(const Tango::DevVarStri
 		sql_query_stream << "SELECT DISTINCT name FROM property WHERE object LIKE \"" << object <<
 		                    "\" AND name LIKE \"" << tmp_wildcard << "\" ORDER BY name";
 	}
-	DEBUG_STREAM << "DataBase::db_get_property_list(): sql_query " << sql_query_stream.str() << endl;
+	DEBUG_STREAM << "DataBase::db_get_property_list(): sql_query " << sql_query_stream.str() << std::endl;
 
     result = query( sql_query_stream.str() , "db_get_property_list()");
 
 	n_rows = mysql_num_rows(result);
-	DEBUG_STREAM << "DataBase::db_get_property_list(): mysql_num_rows() " << n_rows << endl;
+	DEBUG_STREAM << "DataBase::db_get_property_list(): mysql_num_rows() " << n_rows << std::endl;
 	argout = new Tango::DevVarStringArray;
 
 	if (n_rows > 0)
@@ -5342,7 +5342,7 @@ Tango::DevVarStringArray *DataBase::db_get_property_list(const Tango::DevVarStri
 	   {
 	      if ((row = mysql_fetch_row(result)) != NULL)
 	      {
-	         DEBUG_STREAM << "DataBase::db_get_property_list(): property[ "<< i << "] property " << row[0] << endl;
+	         DEBUG_STREAM << "DataBase::db_get_property_list(): property[ "<< i << "] property " << row[0] << std::endl;
 	         (*argout)[i]   = CORBA::string_dup(row[0]);
 	      }
 	   }
@@ -5378,24 +5378,24 @@ Tango::DevVarStringArray *DataBase::db_get_server_info(Tango::DevString argin)
 	argout = new Tango::DevVarStringArray;
 	string tmp_name;
 
-	INFO_STREAM << "DataBase::db_get_server_info(): server " << server_name << endl;
+	INFO_STREAM << "DataBase::db_get_server_info(): server " << server_name << std::endl;
 
 	argout->length(4);
 	(*argout)[0] = CORBA::string_dup(server_name);
 
 //	tmp_name = replace_wildcard(server_name);
     sql_query_stream << "SELECT host,mode,level FROM server WHERE name = '" << server_name << "';";
-	DEBUG_STREAM << "DataBase::db_get_server_info(): sql_query " << sql_query_stream.str() << endl;
+	DEBUG_STREAM << "DataBase::db_get_server_info(): sql_query " << sql_query_stream.str() << std::endl;
 
 	result = query(sql_query_stream.str(),"db_get_server_info()");
 
 	n_rows = mysql_num_rows(result);
-	DEBUG_STREAM << "DataBase::db_get_server_info(): mysql_num_rows() " << n_rows << endl;
+	DEBUG_STREAM << "DataBase::db_get_server_info(): mysql_num_rows() " << n_rows << std::endl;
 	if (n_rows > 0)
 	{
 	   if ((row = mysql_fetch_row(result)) != NULL)
 	   {
-	      DEBUG_STREAM << "DataBase::db_get_server_info(): host "<< row[0] << " mode " << row[1] << " level " << row[2] << endl;
+	      DEBUG_STREAM << "DataBase::db_get_server_info(): host "<< row[0] << " mode " << row[1] << " level " << row[2] << std::endl;
 	      (*argout)[1] = CORBA::string_dup(row[0]);
 	      (*argout)[2] = CORBA::string_dup(row[1]);
 	      (*argout)[3] = CORBA::string_dup(row[2]);
@@ -5440,7 +5440,7 @@ Tango::DevVarStringArray *DataBase::db_get_server_list(Tango::DevString argin)
 	GetTime(before);
 
 
-	INFO_STREAM << "DataBase::db_get_server_list(): wild card " << wildcard << endl;
+	INFO_STREAM << "DataBase::db_get_server_list(): wild card " << wildcard << std::endl;
 
 	if (wildcard == NULL)
 	{
@@ -5452,12 +5452,12 @@ Tango::DevVarStringArray *DataBase::db_get_server_list(Tango::DevString argin)
 		sql_query_stream << "SELECT DISTINCT server FROM device WHERE server LIKE \""
 		                 << tmp_wildcard << "\" ORDER BY server";
 	}
-	DEBUG_STREAM << "DataBase::db_get_server_list(): sql_query " << sql_query_stream.str() << endl;
+	DEBUG_STREAM << "DataBase::db_get_server_list(): sql_query " << sql_query_stream.str() << std::endl;
 
 	result = query(sql_query_stream.str(),"db_get_server_list()");
 
 	n_rows = mysql_num_rows(result);
-	DEBUG_STREAM << "DataBase::db_get_server_list(): mysql_num_rows() " << n_rows << endl;
+	DEBUG_STREAM << "DataBase::db_get_server_list(): mysql_num_rows() " << n_rows << std::endl;
 	argout = new Tango::DevVarStringArray;
 
 	if (n_rows > 0)
@@ -5468,7 +5468,7 @@ Tango::DevVarStringArray *DataBase::db_get_server_list(Tango::DevString argin)
 	   {
 	      if ((row = mysql_fetch_row(result)) != NULL)
 	      {
-//	         DEBUG_STREAM << "DataBase::db_get_server_list(): server[ "<< i << "] alias " << row[0] << endl;
+//	         DEBUG_STREAM << "DataBase::db_get_server_list(): server[ "<< i << "] alias " << row[0] << std::endl;
 	         (*argout)[i]   = CORBA::string_dup(row[0]);
 	      }
 	   }
@@ -5585,7 +5585,7 @@ Tango::DevVarLongStringArray *DataBase::db_import_device(Tango::DevString argin)
 	TimeVal	before, after;
 	GetTime(before);
 
-	INFO_STREAM << "DataBase::ImportDevice(): get import info for " << devname << " device " << endl;
+	INFO_STREAM << "DataBase::ImportDevice(): get import info for " << devname << " device " << std::endl;
 
 	tmp_device = devname;
 	for (unsigned int i=0; i<tmp_device.size(); i++) {
@@ -5604,29 +5604,29 @@ Tango::DevVarLongStringArray *DataBase::db_import_device(Tango::DevString argin)
 
 		sql_query_stream << "SELECT exported,ior,version,pid,server,host,class FROM device WHERE name = '"
 	                 	<< tmp_device << "';";
-		DEBUG_STREAM << "DataBase::ImportDevice(): sql_query " << sql_query_stream.str() << endl;
+		DEBUG_STREAM << "DataBase::ImportDevice(): sql_query " << sql_query_stream.str() << std::endl;
 
 		result = query(sql_query_stream.str(),"db_import_device()",al.get_con_nb());
 
 		n_rows = mysql_num_rows(result);
-		DEBUG_STREAM << "DataBase::ImportDevice(): mysql_num_rows() " << n_rows << endl;
+		DEBUG_STREAM << "DataBase::ImportDevice(): mysql_num_rows() " << n_rows << std::endl;
 
 		if (n_rows <= 0)
 		{
 //
 // could not find device by name, try to look for by alias
 //
-   			INFO_STREAM << "DataBase::ImportDevice(): could not find device by name, look for alias !" << endl;
+   			INFO_STREAM << "DataBase::ImportDevice(): could not find device by name, look for alias !" << std::endl;
 			mysql_free_result(result);
 			sql_query_stream.str("");
 			sql_query_stream << "SELECT exported,ior,version,pid,server,host,class FROM device WHERE alias = '"
 		                	 << tmp_device << "';";
-			DEBUG_STREAM << "DataBase::ImportDevice(): sql_query " << sql_query_stream.str() << endl;
+			DEBUG_STREAM << "DataBase::ImportDevice(): sql_query " << sql_query_stream.str() << std::endl;
 
  	    	result = query(sql_query_stream.str(),"db_import_device()",al.get_con_nb());
 
 			n_rows = mysql_num_rows(result);
-			DEBUG_STREAM << "DataBase::ImportDevice(): mysql_num_rows() " << n_rows << endl;
+			DEBUG_STREAM << "DataBase::ImportDevice(): mysql_num_rows() " << n_rows << std::endl;
 		}
 	}
 
@@ -5638,7 +5638,7 @@ Tango::DevVarLongStringArray *DataBase::db_import_device(Tango::DevString argin)
 	   if ((row = mysql_fetch_row(result)) != NULL)
 	   {
 		  int n_svalues=0, n_lvalues=0;
-	      DEBUG_STREAM << "DataBase::ImportDevice(): device exported " << row[0] << " version " << row[2] << " server " << row[4] << " host " << row[5] << endl;
+	      DEBUG_STREAM << "DataBase::ImportDevice(): device exported " << row[0] << " version " << row[2] << " server " << row[4] << " host " << row[5] << std::endl;
 	      n_svalues = n_svalues+6;
 	      (argout->svalue).length(n_svalues);
 	      (argout->svalue)[n_svalues-6] = CORBA::string_dup(tmp_device.c_str());
@@ -5663,7 +5663,7 @@ Tango::DevVarLongStringArray *DataBase::db_import_device(Tango::DevString argin)
 	      (argout->lvalue)[n_lvalues-1] = pid;
 	   }
 		else {
-	    	 INFO_STREAM << "DataBase::ImportDevice(" << tmp_device << "): info not defined !" << endl;
+	    	 INFO_STREAM << "DataBase::ImportDevice(" << tmp_device << "): info not defined !" << std::endl;
 	    	 mysql_free_result(result);
 		     delete argout;
 	    	 Tango::Except::throw_exception((const char *)DB_DeviceNotDefined,
@@ -5672,7 +5672,7 @@ Tango::DevVarLongStringArray *DataBase::db_import_device(Tango::DevString argin)
 		}
 	}
 	else {
-	     INFO_STREAM << "DataBase::ImportDevice(" << tmp_device << "): device not defined !" << endl;
+	     INFO_STREAM << "DataBase::ImportDevice(" << tmp_device << "): device not defined !" << std::endl;
  	 	 TangoSys_OMemStream o;
 		 o << "device " << tmp_device << " not defined in the database !";
 	     mysql_free_result(result);
@@ -5718,7 +5718,7 @@ Tango::DevVarLongStringArray *DataBase::db_import_event(Tango::DevString argin)
 	TimeVal	before, after;
 	GetTime(before);
 
-	INFO_STREAM << "DataBase::db_import_event(): get import info for " << event_name << endl;
+	INFO_STREAM << "DataBase::db_import_event(): get import info for " << event_name << std::endl;
 
 	tmp_event = event_name;
 	for (unsigned int i=0; i<tmp_event.size(); i++) {
@@ -5727,12 +5727,12 @@ Tango::DevVarLongStringArray *DataBase::db_import_event(Tango::DevString argin)
 	tmp_event = replace_wildcard(tmp_event.c_str());
 
     sql_query_stream << "SELECT exported,ior,version,pid,host FROM event WHERE name = '" << tmp_event << "';";
-	DEBUG_STREAM  << "DataBase::db_import_event(): sql_query " << sql_query_stream.str() << endl;
+	DEBUG_STREAM  << "DataBase::db_import_event(): sql_query " << sql_query_stream.str() << std::endl;
 
 	result = query(sql_query_stream.str(),"db_import_event()");
 
 	n_rows = mysql_num_rows(result);
-	DEBUG_STREAM << "DataBase::db_import_event(): mysql_num_rows() " << n_rows << endl;
+	DEBUG_STREAM << "DataBase::db_import_event(): mysql_num_rows() " << n_rows << std::endl;
 
 	argout = new Tango::DevVarLongStringArray;
 	if (n_rows > 0)
@@ -5741,7 +5741,7 @@ Tango::DevVarLongStringArray *DataBase::db_import_event(Tango::DevString argin)
 	   if ((row = mysql_fetch_row(result)) != NULL)
 	   {
 		  int n_svalues=0, n_lvalues=0;
-	      DEBUG_STREAM << "DataBase::db_import_event(): device exported " << row[0] << " IOR  " << row[1] << " version " << row[2] << endl;
+	      DEBUG_STREAM << "DataBase::db_import_event(): device exported " << row[0] << " IOR  " << row[1] << " version " << row[2] << std::endl;
 	      n_svalues = n_svalues+4;
 	      (argout->svalue).length(n_svalues);
 	      (argout->svalue)[n_svalues-4] = CORBA::string_dup(tmp_event.c_str());
@@ -5761,7 +5761,7 @@ Tango::DevVarLongStringArray *DataBase::db_import_event(Tango::DevString argin)
 	   }
 	}
 	else {
-	     INFO_STREAM << "DataBase::db_import_event(): event not defined !" << endl;
+	     INFO_STREAM << "DataBase::db_import_event(): event not defined !" << std::endl;
    	 	 TangoSys_OMemStream o;
 		 o << "event " << tmp_event << " not defined in the database !";
 	     mysql_free_result(result);
@@ -5815,7 +5815,7 @@ Tango::DevVarStringArray *DataBase::db_info()
 	GetTime(before);
 
 
-	INFO_STREAM << "DataBase::db_info(): get general database infos" << endl;
+	INFO_STREAM << "DataBase::db_info(): get general database infos" << std::endl;
 
 	sprintf(info_str,"TANGO Database %s",DataBase::db_name.c_str());
 	n_infos = 1;
@@ -5831,7 +5831,7 @@ Tango::DevVarStringArray *DataBase::db_info()
 // get start time of database
 
 	sql_query_stream << "SELECT started FROM device WHERE name = \"" << DataBase::db_name << "\" ";
-//	DEBUG_STREAM << "DataBase::db_info(): sql_query " << sql_query_stream.str() << endl;
+//	DEBUG_STREAM << "DataBase::db_info(): sql_query " << sql_query_stream.str() << std::endl;
 
     result = query(sql_query_stream.str(),"db_info()");
 
@@ -5841,7 +5841,7 @@ Tango::DevVarStringArray *DataBase::db_info()
 	{
 	   if ((row = mysql_fetch_row(result)) != NULL)
 	   {
-	      DEBUG_STREAM << "DataBase::db_info(): database started " << row[0] << endl;
+	      DEBUG_STREAM << "DataBase::db_info(): database started " << row[0] << std::endl;
 	      sprintf(info_str,"Running since %s",row[0]);
 	   }
 	}
@@ -5859,7 +5859,7 @@ Tango::DevVarStringArray *DataBase::db_info()
 // get number of devices defined
 	sql_query_stream.str("");
 	sql_query_stream << "SELECT COUNT(*) FROM device ";
-//	DEBUG_STREAM << "DataBase::db_info(): sql_query " << sql_query_stream.str() << endl;
+//	DEBUG_STREAM << "DataBase::db_info(): sql_query " << sql_query_stream.str() << std::endl;
 
     result = query(sql_query_stream.str(),"db_info()");
 
@@ -5869,7 +5869,7 @@ Tango::DevVarStringArray *DataBase::db_info()
 	{
 	   if ((row = mysql_fetch_row(result)) != NULL)
 	   {
-	      DEBUG_STREAM << "DataBase::db_info(): no. of devices " << row[0] << endl;
+	      DEBUG_STREAM << "DataBase::db_info(): no. of devices " << row[0] << std::endl;
 	      sprintf(info_str,"Devices defined  = %s",row[0]);
 	   }
 	}
@@ -5882,7 +5882,7 @@ Tango::DevVarStringArray *DataBase::db_info()
 
 	sql_query_stream.str("");
 	sql_query_stream << "SELECT COUNT(*) FROM device WHERE exported = 1 ";
-//	DEBUG_STREAM << "DataBase::db_info(): sql_query " << sql_query_stream.str() << endl;
+//	DEBUG_STREAM << "DataBase::db_info(): sql_query " << sql_query_stream.str() << std::endl;
 
     result = query(sql_query_stream.str(),"db_info()");
 
@@ -5892,7 +5892,7 @@ Tango::DevVarStringArray *DataBase::db_info()
 	{
 	   if ((row = mysql_fetch_row(result)) != NULL)
 	   {
-	      DEBUG_STREAM << "DataBase::db_info(): no. of devices exported " << row[0] << endl;
+	      DEBUG_STREAM << "DataBase::db_info(): no. of devices exported " << row[0] << std::endl;
 	      sprintf(info_str,"Devices exported  = %s",row[0]);
 	   }
 	}
@@ -5905,7 +5905,7 @@ Tango::DevVarStringArray *DataBase::db_info()
 
 	sql_query_stream.str("");
 	sql_query_stream << "SELECT COUNT(*) FROM device WHERE class = \"DServer\" ";
-//	DEBUG_STREAM << "DataBase::db_info(): sql_query " << sql_query_stream.str() << endl;
+//	DEBUG_STREAM << "DataBase::db_info(): sql_query " << sql_query_stream.str() << std::endl;
 
     result = query(sql_query_stream.str(),"db_info()");
 
@@ -5915,7 +5915,7 @@ Tango::DevVarStringArray *DataBase::db_info()
 	{
 	   if ((row = mysql_fetch_row(result)) != NULL)
 	   {
-	      DEBUG_STREAM << "DataBase::db_info(): no. of device servers defined " << row[0] << endl;
+	      DEBUG_STREAM << "DataBase::db_info(): no. of device servers defined " << row[0] << std::endl;
 	      sprintf(info_str,"Device servers defined  = %s",row[0]);
 	   }
 	}
@@ -5928,7 +5928,7 @@ Tango::DevVarStringArray *DataBase::db_info()
 
 	sql_query_stream.str("");
 	sql_query_stream << "SELECT COUNT(*) FROM device WHERE class = \"DServer\" AND exported = 1 ";
-//	DEBUG_STREAM << "DataBase::db_info(): sql_query " << sql_query_stream.str() << endl;
+//	DEBUG_STREAM << "DataBase::db_info(): sql_query " << sql_query_stream.str() << std::endl;
 
     result = query(sql_query_stream.str(),"db_info()");
 
@@ -5938,7 +5938,7 @@ Tango::DevVarStringArray *DataBase::db_info()
 	{
 	   if ((row = mysql_fetch_row(result)) != NULL)
 	   {
-	      DEBUG_STREAM << "DataBase::db_info(): no. of device servers exported " << row[0] << endl;
+	      DEBUG_STREAM << "DataBase::db_info(): no. of device servers exported " << row[0] << std::endl;
 	      sprintf(info_str,"Device servers exported  = %s",row[0]);
 	   }
 	}
@@ -6050,7 +6050,7 @@ Tango::DevVarStringArray *DataBase::db_info()
 	argout->length(n_infos);
 	(*argout)[n_infos-1] = CORBA::string_dup(info_str);
 
-	DEBUG_STREAM << "DataBase::db_info(): argout->length() "<< argout->length() << endl;
+	DEBUG_STREAM << "DataBase::db_info(): argout->length() "<< argout->length() << std::endl;
 
 	GetTime(after);
 	update_timing_stats(before, after, "DbInfo");
@@ -6098,7 +6098,7 @@ void DataBase::db_put_attribute_alias(const Tango::DevVarStringArray *argin)
 					       (const char *)"DataBase::db_put_attribute_alias()");
 		}
 	}
-	INFO_STREAM << "DataBase::db_put_attribute_alias(): put " << tmp_alias << " for attribute " << tmp_name << endl;
+	INFO_STREAM << "DataBase::db_put_attribute_alias(): put " << tmp_alias << " for attribute " << tmp_name << std::endl;
 
 // first check to see if this alias exists
 
@@ -6108,17 +6108,17 @@ void DataBase::db_put_attribute_alias(const Tango::DevVarStringArray *argin)
 		long n_rows=0;
     	sql_query_stream << "SELECT alias from attribute_alias WHERE alias=\'" << tmp_alias
 	                	 << "\' AND name <> \'" << tmp_name << "\'";
-		DEBUG_STREAM << "DataBase::db_put_attribute_alias(): sql_query " << sql_query_stream.str() << endl;
+		DEBUG_STREAM << "DataBase::db_put_attribute_alias(): sql_query " << sql_query_stream.str() << std::endl;
 
 		result = query(sql_query_stream.str(),"db_put_attribute_alias()",al.get_con_nb());
 
 		n_rows = mysql_num_rows(result);
-		DEBUG_STREAM << "DataBase::db_put_attribute_alias(): mysql_num_rows() " << n_rows << endl;
+		DEBUG_STREAM << "DataBase::db_put_attribute_alias(): mysql_num_rows() " << n_rows << std::endl;
 
 		mysql_free_result(result);
 		if (n_rows > 0)
 		{
-		   WARN_STREAM << "DataBase::db_put_attribute_alias(): this alias exists already !" << endl;
+		   WARN_STREAM << "DataBase::db_put_attribute_alias(): this alias exists already !" << std::endl;
     	   TangoSys_OMemStream o;
 		   o << "alias " << tmp_alias << " already exists !";
 		   Tango::Except::throw_exception((const char *)DB_SQLError,
@@ -6133,12 +6133,12 @@ void DataBase::db_put_attribute_alias(const Tango::DevVarStringArray *argin)
 			if (pos != 0) pos++;
 			pos = tmp_name.find("/",pos);
 			if (pos != string::npos) nsep++;
-			WARN_STREAM << "DataBase::db_put_attribute_alias(): found " << nsep << " separators , remaining string " << tmp_name.substr(pos+1) << endl;
+			WARN_STREAM << "DataBase::db_put_attribute_alias(): found " << nsep << " separators , remaining string " << tmp_name.substr(pos+1) << std::endl;
 		}
 		while (pos != string::npos);
 		if (nsep != 3)
 		{
-		   WARN_STREAM << "DataBase::db_put_attribute_alias(): attribute name has bad syntax, must have 3 / in it" << endl;
+		   WARN_STREAM << "DataBase::db_put_attribute_alias(): attribute name has bad syntax, must have 3 / in it" << std::endl;
     	   TangoSys_OMemStream o;
 		   o << "attribute name " << tmp_name << " has bad syntax, must have 3 / in it";
 		   Tango::Except::throw_exception((const char *)DB_SQLError,
@@ -6151,7 +6151,7 @@ void DataBase::db_put_attribute_alias(const Tango::DevVarStringArray *argin)
 
     	sql_query_stream.str("");
 		sql_query_stream << "DELETE FROM attribute_alias WHERE name=\'" << tmp_name << "\'";
-		DEBUG_STREAM << "DataBase::db_put_attribute_alias(): sql_query " << sql_query_stream.str() << endl;
+		DEBUG_STREAM << "DataBase::db_put_attribute_alias(): sql_query " << sql_query_stream.str() << std::endl;
 		simple_query(sql_query_stream.str(),"db_put_attribute_alias()",al.get_con_nb());
 
 // update the new value for this tuple
@@ -6160,7 +6160,7 @@ void DataBase::db_put_attribute_alias(const Tango::DevVarStringArray *argin)
 		sql_query_stream << "INSERT attribute_alias SET alias=\'" << tmp_alias
 	                	 << "\',name=\'" << tmp_name << "\',device=\'" << tmp_device
 						 << "\',attribute=\'" << tmp_attribute << "\',updated=NOW()";
-		DEBUG_STREAM << "DataBase::db_put_attribute_alias(): sql_query " << sql_query_stream.str() << endl;
+		DEBUG_STREAM << "DataBase::db_put_attribute_alias(): sql_query " << sql_query_stream.str() << std::endl;
 		simple_query(sql_query_stream.str(),"db_put_attribute_alias()",al.get_con_nb());
 	}
 
@@ -6192,7 +6192,7 @@ void DataBase::db_put_class_attribute_property(const Tango::DevVarStringArray *a
 	const char *tmp_class, *tmp_attribute, *tmp_name;
 
 	sscanf((*property_list)[1],"%6d",&n_attributes);
-	INFO_STREAM << "DataBase::PutAttributeProperty(): put " << n_attributes << " attributes for device " << (*property_list)[0] << endl;
+	INFO_STREAM << "DataBase::PutAttributeProperty(): put " << n_attributes << " attributes for device " << (*property_list)[0] << std::endl;
 
 	{
 		AutoLock al("LOCK TABLES property_attribute_class WRITE, property_attribute_class_hist WRITE,class_attribute_history_id WRITE",this);
@@ -6214,7 +6214,7 @@ void DataBase::db_put_class_attribute_property(const Tango::DevVarStringArray *a
 			  sql_query_stream << "DELETE FROM property_attribute_class WHERE class LIKE \"" \
 													 << tmp_class << "\" AND attribute LIKE \"" << tmp_attribute \
 													 << "\" AND name LIKE \"" << tmp_name << "\"";
-	    	  DEBUG_STREAM << "DataBase::PutAttributeProperty(): sql_query " << sql_query_stream.str() << endl;
+	    	  DEBUG_STREAM << "DataBase::PutAttributeProperty(): sql_query " << sql_query_stream.str() << std::endl;
 			  simple_query(sql_query_stream.str(),"db_put_class_attribute_property()",al.get_con_nb());
 
 // then insert the new value for this tuple
@@ -6224,7 +6224,7 @@ void DataBase::db_put_class_attribute_property(const Tango::DevVarStringArray *a
 													 << "',name='" << tmp_name \
 													 << "',count='1',value='" << tmp_escaped_string \
 													 << "',updated=NOW(),accessed=NOW()";
-	    	  DEBUG_STREAM << "DataBase::PutAttributeProperty(): sql_query " << sql_query_stream.str() << endl;
+	    	  DEBUG_STREAM << "DataBase::PutAttributeProperty(): sql_query " << sql_query_stream.str() << std::endl;
 			  simple_query(sql_query_stream.str(),"db_put_class_attribute_property()",al.get_con_nb());
 
 // then insert the new value into the history table
@@ -6236,7 +6236,7 @@ void DataBase::db_put_class_attribute_property(const Tango::DevVarStringArray *a
 													 << "',name='" << tmp_name \
 													 << "',id='" << class_attribute_property_hist_id \
 													 << "',count='1',value='" << tmp_escaped_string << "'";
-	    	  DEBUG_STREAM << "DataBase::PutAttributeProperty(): sql_query " << sql_query_stream.str() << endl;
+	    	  DEBUG_STREAM << "DataBase::PutAttributeProperty(): sql_query " << sql_query_stream.str() << std::endl;
 			  simple_query(sql_query_stream.str(),"db_put_class_attribute_property()",al.get_con_nb());
 
 	    	  purge_att_property("property_attribute_class_hist","class",tmp_class,tmp_attribute,tmp_name,al.get_con_nb());
@@ -6278,7 +6278,7 @@ void DataBase::db_put_class_attribute_property2(const Tango::DevVarStringArray *
 	const char *tmp_class, *tmp_attribute, *tmp_name;
 
 	sscanf((*argin)[1],"%6d",&n_attributes);
-	INFO_STREAM << "DataBase::PutClassAttributeProperty2(): put " << n_attributes << " attributes for device " << (*argin)[0] << endl;
+	INFO_STREAM << "DataBase::PutClassAttributeProperty2(): put " << n_attributes << " attributes for device " << (*argin)[0] << std::endl;
 
 	{
 		AutoLock al("LOCK TABLES property_attribute_class WRITE, property_attribute_class_hist WRITE,class_attribute_history_id WRITE",this);
@@ -6301,7 +6301,7 @@ void DataBase::db_put_class_attribute_property2(const Tango::DevVarStringArray *
 				sql_query_stream << "DELETE FROM property_attribute_class WHERE class LIKE \""
 			                	 << tmp_class << "\" AND attribute LIKE \"" << tmp_attribute
 								 << "\" AND name LIKE \"" << tmp_name << "\" ";
-	      		DEBUG_STREAM << "DataBase::PutClassAttributeProperty2(): sql_query " << sql_query_stream.str() << endl;
+	      		DEBUG_STREAM << "DataBase::PutClassAttributeProperty2(): sql_query " << sql_query_stream.str() << std::endl;
 				simple_query(sql_query_stream.str(),"db_put_class_attribute_property2()",al.get_con_nb());
 
 				sscanf((*argin)[j+1], "%6d", &n_rows);
@@ -6320,7 +6320,7 @@ void DataBase::db_put_class_attribute_property2(const Tango::DevVarStringArray *
 									 << "\',name=\'" << tmp_name << "\',count=\'" << tmp_count_str
 									 << "\',value=\'" << tmp_escaped_string
 									 << "\',updated=NOW(),accessed=NOW()";
-	      			DEBUG_STREAM << "DataBase::PutClassAttributeProperty2(): sql_query " << sql_query_stream.str() << endl;
+	      			DEBUG_STREAM << "DataBase::PutClassAttributeProperty2(): sql_query " << sql_query_stream.str() << std::endl;
 			        simple_query(sql_query_stream.str(),"db_put_class_attribute_property2()",al.get_con_nb());
 
 // then insert the new value into the history table
@@ -6331,7 +6331,7 @@ void DataBase::db_put_class_attribute_property2(const Tango::DevVarStringArray *
 									 << "\',name=\'" << tmp_name << "\',count=\'" << tmp_count_str
 									 << "\',id=\'" << class_attribute_property_hist_id
 									 << "\',value=\'" << tmp_escaped_string << "\'";
-	      			DEBUG_STREAM << "DataBase::PutClassAttributeProperty2(): sql_query " << sql_query_stream.str() << endl;
+	      			DEBUG_STREAM << "DataBase::PutClassAttributeProperty2(): sql_query " << sql_query_stream.str() << std::endl;
 			        simple_query(sql_query_stream.str(),"db_put_class_attribute_property2()",al.get_con_nb());
 
 				}
@@ -6376,7 +6376,7 @@ void DataBase::db_put_class_property(const Tango::DevVarStringArray *argin)
 	GetTime(before);
 
 	sscanf((*property_list)[1],"%6d",&n_properties);
-	INFO_STREAM << "DataBase::PutClassProperty(): put " << n_properties << " properties for device " << (*property_list)[0] << endl;
+	INFO_STREAM << "DataBase::PutClassProperty(): put " << n_properties << " properties for device " << (*property_list)[0] << std::endl;
 
 	{
 		AutoLock al("LOCK TABLES property_class WRITE, property_class_hist WRITE, class_history_id WRITE",this);
@@ -6396,7 +6396,7 @@ void DataBase::db_put_class_property(const Tango::DevVarStringArray *argin)
 			sql_query_stream << "DELETE FROM property_class WHERE class LIKE \"" << tmp_class \
 												<< "\" AND name LIKE \"" << tmp_name << "\"";
 
-			DEBUG_STREAM << "DataBase::PutClassProperty(): sql_query " << sql_query_stream.str() << endl;
+			DEBUG_STREAM << "DataBase::PutClassProperty(): sql_query " << sql_query_stream.str() << std::endl;
 		   	simple_query(sql_query_stream.str(),"db_put_class_property()",al.get_con_nb());
 		   	sscanf((*property_list)[k+1], "%6d", &n_rows);
 		   	Tango::DevULong64 class_property_hist_id = get_id("class",al.get_con_nb());
@@ -6412,7 +6412,7 @@ void DataBase::db_put_class_property(const Tango::DevVarStringArray *argin)
 													 << "',count='" << tmp_count_str \
 													 << "',value='" << tmp_escaped_string \
 													 << "',updated=NOW(),accessed=NOW()";
-	    	  	DEBUG_STREAM << "DataBase::PutClassProperty(): sql_query " << sql_query_stream.str() << endl;
+	    	  	DEBUG_STREAM << "DataBase::PutClassProperty(): sql_query " << sql_query_stream.str() << std::endl;
   	    	  	simple_query(sql_query_stream.str(),"db_put_class_property()",al.get_con_nb());
 
 // then insert the new value into the history table
@@ -6422,7 +6422,7 @@ void DataBase::db_put_class_property(const Tango::DevVarStringArray *argin)
 													 << "',count='" << tmp_count_str \
 													 << "',id='" << class_property_hist_id \
 													 << "',value='" << tmp_escaped_string << "'";
-	    	  	DEBUG_STREAM << "DataBase::PutClassProperty(): sql_query " << sql_query_stream.str() << endl;
+	    	  	DEBUG_STREAM << "DataBase::PutClassProperty(): sql_query " << sql_query_stream.str() << std::endl;
   	    	  	simple_query(sql_query_stream.str(),"db_put_class_property()",al.get_con_nb());
 		   	}
 		   	purge_property("property_class_hist","class",tmp_class,tmp_name,al.get_con_nb());
@@ -6477,7 +6477,7 @@ void DataBase::db_put_device_alias(const Tango::DevVarStringArray *argin)
 					       (const char *)"DataBase::db_put_device_alias()");
 		}
 	}
-	INFO_STREAM << "DataBase::db_put_device_alias(): put " << tmp_alias << " for device " << tmp_device << endl;
+	INFO_STREAM << "DataBase::db_put_device_alias(): put " << tmp_alias << " for device " << tmp_device << std::endl;
 
 // first check to see if this alias exists
 
@@ -6486,18 +6486,18 @@ void DataBase::db_put_device_alias(const Tango::DevVarStringArray *argin)
 
     	sql_query_stream << "SELECT alias from device WHERE alias=\'" << tmp_alias
 	                	 << "\' AND name <> \'" << tmp_device << "\'";
-		DEBUG_STREAM << "DataBase::db_put_device_alias(): sql_query " << sql_query_stream.str() << endl;
+		DEBUG_STREAM << "DataBase::db_put_device_alias(): sql_query " << sql_query_stream.str() << std::endl;
 
 		result = query(sql_query_stream.str(),"db_put_device_alias()",al.get_con_nb());
 
 		long n_rows=0;
 		n_rows = mysql_num_rows(result);
-		DEBUG_STREAM << "DataBase::db_put_device_alias(): mysql_num_rows() " << n_rows << endl;
+		DEBUG_STREAM << "DataBase::db_put_device_alias(): mysql_num_rows() " << n_rows << std::endl;
 
 		mysql_free_result(result);
 		if (n_rows > 0)
 		{
-		   WARN_STREAM << "DataBase::db_put_device_alias(): this alias exists already !" << endl;
+		   WARN_STREAM << "DataBase::db_put_device_alias(): this alias exists already !" << std::endl;
     	   TangoSys_OMemStream o;
 		   o << "alias " << tmp_alias << " already exists !";
 		   Tango::Except::throw_exception((const char *)DB_SQLError,
@@ -6509,7 +6509,7 @@ void DataBase::db_put_device_alias(const Tango::DevVarStringArray *argin)
     	sql_query_stream.str("");
 		sql_query_stream << "UPDATE device set alias=\'" << tmp_alias
 	                	 << "\',started=NOW() where name LIKE \'" << tmp_device << "\'";
-		DEBUG_STREAM << "DataBase::db_put_device_alias(): sql_query " << sql_query_stream.str() << endl;
+		DEBUG_STREAM << "DataBase::db_put_device_alias(): sql_query " << sql_query_stream.str() << std::endl;
 		simple_query(sql_query_stream.str(),"db_put_device_alias()",al.get_con_nb());
 	}
 
@@ -6545,7 +6545,7 @@ void DataBase::db_put_device_attribute_property(const Tango::DevVarStringArray *
 
 
 	sscanf((*property_list)[1],"%6d",&n_attributes);
-	INFO_STREAM << "DataBase::PutAttributeProperty(): put " << n_attributes << " attributes for device " << (*property_list)[0] << endl;
+	INFO_STREAM << "DataBase::PutAttributeProperty(): put " << n_attributes << " attributes for device " << (*property_list)[0] << std::endl;
 
 	{
 		AutoLock al("LOCK TABLES property_attribute_device WRITE, property_attribute_device_hist WRITE,device_attribute_history_id WRITE",this);
@@ -6567,7 +6567,7 @@ void DataBase::db_put_device_attribute_property(const Tango::DevVarStringArray *
 				sql_query_stream << "DELETE FROM property_attribute_device WHERE device LIKE \"" \
 												 << tmp_device << "\" AND attribute LIKE \"" << tmp_attribute \
 												 << "\" AND name LIKE \"" << tmp_name << "\"";
-				DEBUG_STREAM << "DataBase::PutAttributeProperty(): sql_query " << sql_query_stream.str() << endl;
+				DEBUG_STREAM << "DataBase::PutAttributeProperty(): sql_query " << sql_query_stream.str() << std::endl;
 
 				simple_query(sql_query_stream.str(),"db_put_device_attribute_property()",al.get_con_nb());
 
@@ -6578,7 +6578,7 @@ void DataBase::db_put_device_attribute_property(const Tango::DevVarStringArray *
 												 << "',name='" << tmp_name \
 												 << "',count='1',value='" << tmp_escaped_string \
 												 << "',updated=NOW(),accessed=NOW()";
-	      		DEBUG_STREAM << "DataBase::PutAttributeProperty(): sql_query " << sql_query_stream.str() << endl;
+	      		DEBUG_STREAM << "DataBase::PutAttributeProperty(): sql_query " << sql_query_stream.str() << std::endl;
 		  		simple_query(sql_query_stream.str(),"db_put_device_attribute_property()",al.get_con_nb());
 
 // then insert the new value for this tuple into the history table
@@ -6589,7 +6589,7 @@ void DataBase::db_put_device_attribute_property(const Tango::DevVarStringArray *
 												 << "',name='" << tmp_name \
 												 << "',id='" << device_attribute_property_hist_id \
 												 << "',count='1',value='" << tmp_escaped_string << "'";
-	      		DEBUG_STREAM << "DataBase::PutAttributeProperty(): sql_query " << sql_query_stream.str() << endl;
+	      		DEBUG_STREAM << "DataBase::PutAttributeProperty(): sql_query " << sql_query_stream.str() << std::endl;
 		  		simple_query(sql_query_stream.str(),"db_put_device_attribute_property()",al.get_con_nb());
 
 	      		purge_att_property("property_attribute_device_hist","device",tmp_device,tmp_attribute,tmp_name,al.get_con_nb());
@@ -6647,7 +6647,7 @@ void DataBase::db_put_device_attribute_property2(const Tango::DevVarStringArray 
     else
     {
         sscanf((*argin)[1],"%6d",&n_attributes);
-        INFO_STREAM << "DataBase::PutAttributeProperty2(): put " << n_attributes << " attributes for device " << (*argin)[0] << endl;
+        INFO_STREAM << "DataBase::PutAttributeProperty2(): put " << n_attributes << " attributes for device " << (*argin)[0] << std::endl;
 
         {
             AutoLock al("LOCK TABLES property_attribute_device WRITE, property_attribute_device_hist WRITE,device_attribute_history_id WRITE",this);
@@ -6669,7 +6669,7 @@ void DataBase::db_put_device_attribute_property2(const Tango::DevVarStringArray 
                     sql_query_stream << "DELETE FROM property_attribute_device WHERE device LIKE \""
                                          << tmp_device << "\" AND attribute LIKE \"" << tmp_attribute
                                          << "\" AND name LIKE \"" << tmp_name << "\" ";
-                    DEBUG_STREAM << "DataBase::PutAttributeProperty2(): sql_query " << sql_query_stream.str() << endl;
+                    DEBUG_STREAM << "DataBase::PutAttributeProperty2(): sql_query " << sql_query_stream.str() << std::endl;
                     simple_query(sql_query_stream.str(),"db_put_device_attribute_property2()",al.get_con_nb());
 
                     sscanf((*argin)[j+1], "%6d", &n_rows);
@@ -6687,7 +6687,7 @@ void DataBase::db_put_device_attribute_property2(const Tango::DevVarStringArray 
                                              << tmp_device << "\',attribute=\'" << tmp_attribute
                                              << "\',name=\'" << tmp_name << "\',count=\'" << tmp_count_str
                                              << "\',value=\'" << tmp_escaped_string << "\',updated=NOW(),accessed=NOW()";
-                        DEBUG_STREAM << "DataBase::PutAttributeProperty(): sql_query " << sql_query_stream.str() << endl;
+                        DEBUG_STREAM << "DataBase::PutAttributeProperty(): sql_query " << sql_query_stream.str() << std::endl;
                         simple_query(sql_query_stream.str(),"db_put_device_attribute_property2()",al.get_con_nb());
 
 // then insert the new value into the history table
@@ -6697,7 +6697,7 @@ void DataBase::db_put_device_attribute_property2(const Tango::DevVarStringArray 
                                              << "\',name=\'" << tmp_name << "\',count=\'" << tmp_count_str
                                              << "\',id=\'" << device_attribute_property_hist_id
                                              << "\',value=\'" << tmp_escaped_string << "\'";
-                        DEBUG_STREAM << "DataBase::PutAttributeProperty(): sql_query " << sql_query_stream.str() << endl;
+                        DEBUG_STREAM << "DataBase::PutAttributeProperty(): sql_query " << sql_query_stream.str() << std::endl;
                         simple_query(sql_query_stream.str(),"db_put_device_attribute_property2()",al.get_con_nb());
 
                     }
@@ -6746,7 +6746,7 @@ void DataBase::db_put_device_property(const Tango::DevVarStringArray *argin)
 	GetTime(before);
 
 	sscanf((*property_list)[1],"%6d",&n_properties);
-	INFO_STREAM << "DataBase::PutDeviceProperty(): put " << n_properties << " properties for device " << (*property_list)[0] << endl;
+	INFO_STREAM << "DataBase::PutDeviceProperty(): put " << n_properties << " properties for device " << (*property_list)[0] << std::endl;
 
 	{
 		AutoLock al("LOCK TABLES property_device WRITE, property_device_hist WRITE,device_history_id WRITE",this);
@@ -6765,7 +6765,7 @@ void DataBase::db_put_device_property(const Tango::DevVarStringArray *argin)
     	   sql_query_stream.str("");
 		   sql_query_stream << "DELETE FROM property_device WHERE device LIKE \"" << tmp_device \
 													 << "\" AND name LIKE \"" << tmp_name << "\"";
-		   DEBUG_STREAM << "DataBase::PutDeviceProperty(): sql_query " << sql_query_stream.str() << endl;
+		   DEBUG_STREAM << "DataBase::PutDeviceProperty(): sql_query " << sql_query_stream.str() << std::endl;
 
 		   simple_query(sql_query_stream.str(),"db_put_device_property()",al.get_con_nb());
 		   sscanf((*property_list)[k+1], "%6d", &n_rows);
@@ -6783,7 +6783,7 @@ void DataBase::db_put_device_property(const Tango::DevVarStringArray *argin)
 													 << "',count='" << tmp_count_str \
 													 << "',value='" << tmp_escaped_string \
 													 << "',updated=NOW(),accessed=NOW()";
-	    	  DEBUG_STREAM << "DataBase::PutDeviceProperty(): sql_query " << sql_query_stream.str() << endl;
+	    	  DEBUG_STREAM << "DataBase::PutDeviceProperty(): sql_query " << sql_query_stream.str() << std::endl;
 
 			  simple_query(sql_query_stream.str(),"db_put_device_property",al.get_con_nb());
 
@@ -6796,7 +6796,7 @@ void DataBase::db_put_device_property(const Tango::DevVarStringArray *argin)
 													 << "',value='" << tmp_escaped_string \
 													 << "'";
 
-	    	  DEBUG_STREAM << "DataBase::PutDeviceProperty(): sql_query " << sql_query_stream.str() << endl;
+	    	  DEBUG_STREAM << "DataBase::PutDeviceProperty(): sql_query " << sql_query_stream.str() << std::endl;
 
 			  simple_query(sql_query_stream.str(),"db_put_device_property",al.get_con_nb());
 
@@ -6840,7 +6840,7 @@ void DataBase::db_put_property(const Tango::DevVarStringArray *argin)
 
 	tmp_object = (*property_list)[0];
 	sscanf((*property_list)[1],"%6d", &n_properties);
-	INFO_STREAM << "DataBase::db_put_property(): put " << n_properties << " properties for object " << (*property_list)[0] << endl;
+	INFO_STREAM << "DataBase::db_put_property(): put " << n_properties << " properties for object " << (*property_list)[0] << std::endl;
 
 	{
 		AutoLock al("LOCK TABLES property WRITE, property_hist WRITE,object_history_id WRITE",this);
@@ -6858,7 +6858,7 @@ void DataBase::db_put_property(const Tango::DevVarStringArray *argin)
 			sql_query_stream.str("");
 			sql_query_stream << "DELETE FROM property WHERE object=\"" << tmp_object
 											 << "\" AND name=\"" << tmp_name << "\"";
-			DEBUG_STREAM  << "DataBase::db_put_property(): sql_query " << sql_query_stream.str() << endl;
+			DEBUG_STREAM  << "DataBase::db_put_property(): sql_query " << sql_query_stream.str() << std::endl;
 
 			simple_query(sql_query_stream.str(),"db_put_property()",al.get_con_nb());
 			Tango::DevULong64 object_property_hist_id = get_id("object",al.get_con_nb());
@@ -6874,7 +6874,7 @@ void DataBase::db_put_property(const Tango::DevVarStringArray *argin)
 											 << "',count='" << tmp_count
 											 << "',value='" << tmp_escaped_string
 											 << "',updated=NOW(),accessed=NOW()";
-	    	  DEBUG_STREAM << "DataBase::db_put_property(): sql_query " << sql_query_stream.str() << endl;
+	    	  DEBUG_STREAM << "DataBase::db_put_property(): sql_query " << sql_query_stream.str() << std::endl;
 			  simple_query(sql_query_stream.str(),"db_put_property()",al.get_con_nb());
 
 			  // then insert the new value into history table
@@ -6884,7 +6884,7 @@ void DataBase::db_put_property(const Tango::DevVarStringArray *argin)
 											 << "',count='" << tmp_count
 											 << "',id='" << object_property_hist_id
 											 << "',value='" << tmp_escaped_string << "'";
-	    	  DEBUG_STREAM << "DataBase::db_put_property(): sql_query " << sql_query_stream.str() << endl;
+	    	  DEBUG_STREAM << "DataBase::db_put_property(): sql_query " << sql_query_stream.str() << std::endl;
 			  simple_query(sql_query_stream.str(),"db_put_property()",al.get_con_nb());
 			}
 			purge_property("property_hist","object",tmp_object,tmp_name.c_str(),al.get_con_nb());
@@ -6917,13 +6917,13 @@ void DataBase::db_put_server_info(const Tango::DevVarStringArray *argin)
 
 	if (server_info->length() < 4) {
    		WARN_STREAM << "DataBase::db_put_server_info(): insufficient info for server ";
-   		WARN_STREAM << endl;
+   		WARN_STREAM << std::endl;
    		Tango::Except::throw_exception((const char *)DB_IncorrectArguments,
 					       (const char *)"insufficient server info",
 					       (const char *)"DataBase::db_put_server_info()");
 	}
 
-	INFO_STREAM << "DataBase::db_put_server_info(): put " << server_info->length()-1 << " export info for device " << (*server_info)[0] << endl;
+	INFO_STREAM << "DataBase::db_put_server_info(): put " << server_info->length()-1 << " export info for device " << (*server_info)[0] << std::endl;
 
 	tmp_server = (*server_info)[0];
 
@@ -6959,14 +6959,14 @@ void DataBase::db_put_server_info(const Tango::DevVarStringArray *argin)
 
 				char *tmp_ptr = db_get_device_host((Tango::DevString)adm_dev.c_str(),al.get_con_nb());
 				previous_host = tmp_ptr;
-				DEBUG_STREAM << tmp_server << " was running on " << previous_host << endl;
+				DEBUG_STREAM << tmp_server << " was running on " << previous_host << std::endl;
 				CORBA::string_free(tmp_ptr);
 			}
 		}
 // first delete the server from the server table
 
 		sql_query_stream << "DELETE FROM server WHERE name = \"" << tmp_server << "\"";
-		DEBUG_STREAM << "DataBase::db_put_server_info(): sql_query " << sql_query_stream.str() << endl;
+		DEBUG_STREAM << "DataBase::db_put_server_info(): sql_query " << sql_query_stream.str() << std::endl;
 		simple_query(sql_query_stream.str(),"db_put_server_info()",al.get_con_nb());
 
 // insert the new info for this server
@@ -6974,7 +6974,7 @@ void DataBase::db_put_server_info(const Tango::DevVarStringArray *argin)
     	sql_query_stream.str("");
 		sql_query_stream << "INSERT INTO server SET name=\'" << tmp_server << "\',host=\'"
 	                	 << tmp_host << "\',mode=\'" << tmp_mode << "\',level=\'" << tmp_level << "\'";
-		DEBUG_STREAM << "DataBase::db_put_server_info(): sql_query " << sql_query_stream.str() << endl;
+		DEBUG_STREAM << "DataBase::db_put_server_info(): sql_query " << sql_query_stream.str() << std::endl;
 		simple_query(sql_query_stream.str(),"db_put_server_info()",al.get_con_nb());
 	}
 
@@ -7011,7 +7011,7 @@ void DataBase::db_un_export_device(Tango::DevString argin)
 	TangoSys_MemStream sql_query_stream;
 	char *tmp_device;
 
-	INFO_STREAM << "DataBase::UnExportDevice(): un-export " << devname << " device " << endl;
+	INFO_STREAM << "DataBase::UnExportDevice(): un-export " << devname << " device " << std::endl;
 
 	tmp_device = (char*)malloc(strlen(devname)+1);
 	sprintf(tmp_device,"%s",devname);
@@ -7022,7 +7022,7 @@ void DataBase::db_un_export_device(Tango::DevString argin)
 // un-export device from database by seting ior="not exported"
     sql_query_stream << "UPDATE device SET exported=0,stopped=NOW() WHERE name like \""
 	                 << tmp_device << "\"";
-	DEBUG_STREAM << "DataBase::UnExportDevice(): sql_query " << sql_query_stream.str() << endl;
+	DEBUG_STREAM << "DataBase::UnExportDevice(): sql_query " << sql_query_stream.str() << std::endl;
 	simple_query(sql_query_stream.str(),"db_export_device()");
 
 	free(tmp_device);
@@ -7049,7 +7049,7 @@ void DataBase::db_un_export_event(Tango::DevString argin)
 	TangoSys_MemStream sql_query_stream;
 	string tmp_event;
 
-	INFO_STREAM << "DataBase::un_export_event(): un-export " << event_name << " device " << endl;
+	INFO_STREAM << "DataBase::un_export_event(): un-export " << event_name << " device " << std::endl;
 
 	tmp_event = event_name;
 	for (unsigned int i=0; i<tmp_event.size(); i++) {
@@ -7060,7 +7060,7 @@ void DataBase::db_un_export_event(Tango::DevString argin)
 // un-export event from database by seting ior="not exported"
 
 	sql_query_stream << "UPDATE event SET exported=0,stopped=NOW() WHERE name like \"" << tmp_event << "\"";
-	DEBUG_STREAM << "DataBase::un_export_event(): sql_query " << sql_query_stream.str() << endl;
+	DEBUG_STREAM << "DataBase::un_export_event(): sql_query " << sql_query_stream.str() << std::endl;
 	simple_query(sql_query_stream.str(),"db_un_export_event()");
 
 	/*----- PROTECTED REGION END -----*/	//	DataBase::db_un_export_event
@@ -7087,7 +7087,7 @@ void DataBase::db_un_export_server(Tango::DevString argin)
 	TimeVal	before, after;
 	GetTime(before);
 
-	INFO_STREAM << "DataBase::UnExportServer(): un-export all device(s) from server " << server_name << " device " << endl;
+	INFO_STREAM << "DataBase::UnExportServer(): un-export all device(s) from server " << server_name << " device " << std::endl;
 
 	tmp_server = (char*)malloc(strlen(server_name)+1);
 	sprintf(tmp_server,"%s",server_name);
@@ -7099,7 +7099,7 @@ void DataBase::db_un_export_server(Tango::DevString argin)
 
 	sql_query_stream << "UPDATE device SET exported=0,stopped=NOW() WHERE server like \""
 	                 << tmp_server << "\"";
-	DEBUG_STREAM << "DataBase::UnExportServer(): sql_query " << sql_query_stream.str() << endl;
+	DEBUG_STREAM << "DataBase::UnExportServer(): sql_query " << sql_query_stream.str() << std::endl;
 	simple_query(sql_query_stream.str(),"db_un_export_server()");
 
 	free(tmp_server);
@@ -7163,13 +7163,13 @@ Tango::DevVarStringArray *DataBase::db_get_data_for_server_cache(const Tango::De
 	//		(chapter : Writing a TANGO DS / Exchanging data)
 	//------------------------------------------------------------
 
-	DEBUG_STREAM << "DataBase::db_get_data_for_server_cache(): entering... !" << endl;
+	DEBUG_STREAM << "DataBase::db_get_data_for_server_cache(): entering... !" << std::endl;
 
 	//	Add your own code to control device here
 
 	if (argin->length() != 2)
 	{
-	   WARN_STREAM << "DataBase::DbGetDataForServerCache(): incorrect number of input arguments " << endl;
+	   WARN_STREAM << "DataBase::DbGetDataForServerCache(): incorrect number of input arguments " << std::endl;
 	   Tango::Except::throw_exception((const char *)DB_IncorrectArguments,
 	   				  (const char *)"Incorrect no. of input arguments, needs 2 (ds_name,host_name)",
 					  (const char *)"DataBase::DbGetDataForServerCache()");
@@ -7177,7 +7177,7 @@ Tango::DevVarStringArray *DataBase::db_get_data_for_server_cache(const Tango::De
 
 	if (mysql_svr_version < 50000)
 	{
-		WARN_STREAM << "DataBase::DbGetDataForServerCache(): MySQL server too old for this command" << endl;
+		WARN_STREAM << "DataBase::DbGetDataForServerCache(): MySQL server too old for this command" << std::endl;
 		Tango::Except::throw_exception((const char *)"DB_MySQLServerTooOld",
 						(const char *)"The MySQL server release does not support stored procedure. Update MySQL to release >= 5",
 						(const char *)"DataBase::DbGetDataForServerCache()");
@@ -7211,7 +7211,7 @@ Tango::DevVarStringArray *DataBase::db_get_data_for_server_cache(const Tango::De
 	sql_query = sql_query + mysql_db_name;
 	sql_query = sql_query + ".ds_start('" + svc + "','" + host + "'," + tmp_var_name + ")";
 	sql_query = sql_query + ";SELECT " + tmp_var_name;
-//  cout << "Query = " << sql_query << endl;
+//  cout << "Query = " << sql_query << std::endl;
 
 	int con_nb = get_connection();
 	if (mysql_real_query(conn_pool[con_nb].db, sql_query.c_str(),sql_query.length()) != 0)
@@ -7219,12 +7219,12 @@ Tango::DevVarStringArray *DataBase::db_get_data_for_server_cache(const Tango::De
 		delete argout;
 		TangoSys_OMemStream o;
 
-		WARN_STREAM << "DataBase::db_get_data_for_server_cache failed to query TANGO database:" << endl;
-		WARN_STREAM << "  query = " << sql_query << endl;
-		WARN_STREAM << " (SQL error=" << mysql_error(conn_pool[con_nb].db) << ")" << endl;
+		WARN_STREAM << "DataBase::db_get_data_for_server_cache failed to query TANGO database:" << std::endl;
+		WARN_STREAM << "  query = " << sql_query << std::endl;
+		WARN_STREAM << " (SQL error=" << mysql_error(conn_pool[con_nb].db) << ")" << std::endl;
 
 		o << "Failed to query TANGO database (error=" << mysql_error(conn_pool[con_nb].db) << ")";
-		o << "\nThe query was: " << sql_query << ends;
+		o << "\nThe query was: " << sql_query << std::ends;
 
 		release_connection(con_nb);
 
@@ -7246,7 +7246,7 @@ Tango::DevVarStringArray *DataBase::db_get_data_for_server_cache(const Tango::De
 				delete argout;
 				TangoSys_OMemStream o;
 
-				WARN_STREAM << "DataBase::db_get_data_for_server_cache: mysql_store_result() failed  (error=" << mysql_error(conn_pool[con_nb].db) << ")" << endl;
+				WARN_STREAM << "DataBase::db_get_data_for_server_cache: mysql_store_result() failed  (error=" << mysql_error(conn_pool[con_nb].db) << ")" << std::endl;
 
 				o << "mysql_store_result() failed (error=" << mysql_error(conn_pool[con_nb].db) << ")";
 
@@ -7261,7 +7261,7 @@ Tango::DevVarStringArray *DataBase::db_get_data_for_server_cache(const Tango::De
 				delete argout;
 				TangoSys_OMemStream o;
 
-				WARN_STREAM << "DataBase::db_get_data_for_server_cache: mysql_next_result() failed  (error=" << mysql_error(conn_pool[con_nb].db) << ")" << endl;
+				WARN_STREAM << "DataBase::db_get_data_for_server_cache: mysql_next_result() failed  (error=" << mysql_error(conn_pool[con_nb].db) << ")" << std::endl;
 
 				o << "mysql_next_result() failed (error=" << mysql_error(conn_pool[con_nb].db) << ")";
 
@@ -7291,7 +7291,7 @@ Tango::DevVarStringArray *DataBase::db_get_data_for_server_cache(const Tango::De
 		{
 			delete argout;
 			mysql_free_result(res);
-			WARN_STREAM << "DataBase::DbGetDataForServerCache(): Stored procedure does not return any result!!!" << endl;
+			WARN_STREAM << "DataBase::DbGetDataForServerCache(): Stored procedure does not return any result!!!" << std::endl;
 			Tango::Except::throw_exception((const char *)"DB_StoredProcedureNoResult",
 						(const char *)"The stored procedure did not return any results!!!",
 						(const char *)"DataBase::DbGetDataForServerCache()");
@@ -7300,7 +7300,7 @@ Tango::DevVarStringArray *DataBase::db_get_data_for_server_cache(const Tango::De
 		{
 			delete argout;
 			mysql_free_result(res);
-			WARN_STREAM << "DataBase::DbGetDataForServerCache(): Stored procedure failed with a MySQL error!!!" << endl;
+			WARN_STREAM << "DataBase::DbGetDataForServerCache(): Stored procedure failed with a MySQL error!!!" << std::endl;
 			Tango::Except::throw_exception((const char *)"DB_StoredProcedureFailed",
 						(const char *)"The stored procedure failed with a MySQL error!!!",
 						(const char *)"DataBase::DbGetDataForServerCache()");
@@ -7357,7 +7357,7 @@ void DataBase::db_delete_all_device_attribute_property(const Tango::DevVarString
 
 	if (argin->length() < 2) {
    		WARN_STREAM << "DataBase::db_delete_all_device_attribute_property(): insufficient number of arguments ";
-   		WARN_STREAM << endl;
+   		WARN_STREAM << std::endl;
    		Tango::Except::throw_exception((const char *)DB_IncorrectArguments,
 					       (const char *)"insufficient number of arguments to delete all device attribute(s) property",
 					       (const char *)"DataBase::db_delete_all_device_attribute_property()");
@@ -7367,7 +7367,7 @@ void DataBase::db_delete_all_device_attribute_property(const Tango::DevVarString
 	if (!check_device_name(tmp_device))
 	{
         	WARN_STREAM << "DataBase::db_delete_all_device_attribute(): device name  " << tmp_device << " incorrect ";
-         	WARN_STREAM << endl;
+         	WARN_STREAM << std::endl;
          	Tango::Except::throw_exception((const char *)DB_IncorrectDeviceName,
 				       	(const char *)"Failed to delete all device attribute(s) property, device name incorrect",
 				       	(const char *)"DataBase::db_delete_all_device_attribute()");
@@ -7382,7 +7382,7 @@ void DataBase::db_delete_all_device_attribute_property(const Tango::DevVarString
 			attribute = (*argin)[i+1];
 
 			INFO_STREAM << "DataBase::db_delete_all_device_attribute_property(): delete device " << tmp_device ;
-			INFO_STREAM << " attribute " << attribute << " property(ies) from database" << endl;
+			INFO_STREAM << " attribute " << attribute << " property(ies) from database" << std::endl;
 
 // Is there something to delete ?
 
@@ -7400,7 +7400,7 @@ void DataBase::db_delete_all_device_attribute_property(const Tango::DevVarString
 				sql_query_stream.str("");
 				sql_query_stream << "DELETE FROM property_attribute_device WHERE device = \"" << tmp_device
 		       					<<"\" AND attribute = \"" << attribute << "\" ";
-				DEBUG_STREAM << "DataBase::db_delete_all_device_attribute_property(): sql_query " << sql_query_stream.str() << endl;
+				DEBUG_STREAM << "DataBase::db_delete_all_device_attribute_property(): sql_query " << sql_query_stream.str() << std::endl;
 				simple_query(sql_query_stream.str(),"db_delete_all_device_attribute_property()",al.get_con_nb());
 
 // Mark this property as deleted
@@ -7415,7 +7415,7 @@ void DataBase::db_delete_all_device_attribute_property(const Tango::DevVarString
 			   					 << "',name='" << row[0]
 			   					 << "',id='" << device_attribute_property_hist_id
 			   					 << "',count='0',value='DELETED'";
-					DEBUG_STREAM << "DataBase::DeletAllDeviceAttributeProperty(): sql_query " << sql_query_stream.str() << endl;
+					DEBUG_STREAM << "DataBase::DeletAllDeviceAttributeProperty(): sql_query " << sql_query_stream.str() << std::endl;
 					simple_query(sql_query_stream.str(),"db_delete_all_device_attribute_property()",al.get_con_nb());
 					purge_att_property("property_attribute_device_hist","device",tmp_device.c_str(),attribute,row[0],al.get_con_nb());
 				}
@@ -7467,20 +7467,20 @@ Tango::DevVarLongStringArray *DataBase::db_my_sql_select(Tango::DevString argin)
  	    TangoSys_OMemStream o;
 		o << "SQL command not valid: \'" << argin << "\'";
 		string msg = o.str();
-		WARN_STREAM << msg << endl;
+		WARN_STREAM << msg << std::endl;
 		Tango::Except::throw_exception((const char *)DB_IncorrectArguments,
 	   				                   msg,
 					                   (const char *)"DataBase::db_my_sql_select()");
 	}
 
-	INFO_STREAM << "DataBase::db_my_sql_select(): \ncmd: " << cmd << endl;
+	INFO_STREAM << "DataBase::db_my_sql_select(): \ncmd: " << cmd << std::endl;
 
 	MYSQL_RES	*result   = query(cmd, "db_my_sql_select()");
 	int			nb_rows   = mysql_num_rows(result);
 	int			nb_fields = mysql_num_fields(result);
 	int			nb_data   = nb_rows*nb_fields;
 
-	DEBUG_STREAM << "DataBase::db_my_sql_select(): mysql_num_rows() " << nb_rows << endl;
+	DEBUG_STREAM << "DataBase::db_my_sql_select(): mysql_num_rows() " << nb_rows << std::endl;
 
 
 	argout = new Tango::DevVarLongStringArray;
@@ -7544,12 +7544,12 @@ Tango::DevVarStringArray *DataBase::db_get_csdb_server_list()
 
 	sql_query_stream << "SELECT DISTINCT ior FROM device WHERE exported=1 AND domain=\'sys\' AND family=\'database\'";
 
-	DEBUG_STREAM << "DataBase::db_get_csdb_server_list(): sql_query " << sql_query_stream.str() << endl;
+	DEBUG_STREAM << "DataBase::db_get_csdb_server_list(): sql_query " << sql_query_stream.str() << std::endl;
 
 	result = query(sql_query_stream.str(),"db_get_csdb_server_list()");
 
 	n_rows = mysql_num_rows(result);
-	DEBUG_STREAM << "DataBase::db_get_csdb_server_list(): mysql_num_rows() " << n_rows << endl;
+	DEBUG_STREAM << "DataBase::db_get_csdb_server_list(): mysql_num_rows() " << n_rows << std::endl;
 	argout = new Tango::DevVarStringArray;
 
 	if (n_rows > 0)
@@ -7559,7 +7559,7 @@ Tango::DevVarStringArray *DataBase::db_get_csdb_server_list()
 	   {
 	      if ((row = mysql_fetch_row(result)) != NULL)
 	      {
-	         DEBUG_STREAM << "DataBase::db_get_csdb_server_list(): ior[ "<< i << "] " << row[0] << endl;
+	         DEBUG_STREAM << "DataBase::db_get_csdb_server_list(): ior[ "<< i << "] " << row[0] << std::endl;
 			 string h_p;
 			 bool ret = host_port_from_ior(row[0],h_p);
 			 if (ret == true)
@@ -7571,7 +7571,7 @@ Tango::DevVarStringArray *DataBase::db_get_csdb_server_list()
  	    		TangoSys_OMemStream o;
 				o << "Wrong IOR in database for at least one of the database server(s)";
 				string msg = o.str();
-				WARN_STREAM << msg << endl;
+				WARN_STREAM << msg << std::endl;
 				Tango::Except::throw_exception((const char *)"DB_WrongIORForDbServer",
 	   				                   msg,
 					                   (const char *)"DataBase::db_get_csdb_server_list()");
@@ -7609,23 +7609,23 @@ Tango::DevString DataBase::db_get_attribute_alias2(Tango::DevString argin)
 	long n_rows=0;
 	argout  = new char[256];
 
-	INFO_STREAM << "DataBase::db_get_attribute_alias2(): get " << argin << endl;
+	INFO_STREAM << "DataBase::db_get_attribute_alias2(): get " << argin << std::endl;
 
 // first check to see if this alias exists
 
 	sql_query_stream << "SELECT alias from attribute_alias WHERE name LIKE \'" << argin << "\' ";
-	DEBUG_STREAM << "DataBase::db_get_attribute_alias2(): sql_query " << sql_query_stream.str() << endl;
+	DEBUG_STREAM << "DataBase::db_get_attribute_alias2(): sql_query " << sql_query_stream.str() << std::endl;
 
 	result = query(sql_query_stream.str(),"db_get_attribute_alias2()");
 
 	n_rows = mysql_num_rows(result);
-	DEBUG_STREAM << "DataBase::db_get_attribute_alias2(): mysql_num_rows() " << n_rows << endl;
+	DEBUG_STREAM << "DataBase::db_get_attribute_alias2(): mysql_num_rows() " << n_rows << std::endl;
 
 	if (n_rows > 0)
 	{
         if ((row = mysql_fetch_row(result)) != NULL)
         {
-            DEBUG_STREAM << "DataBase::db_get_attribute_alias2(): attribute name "<< row[0] << endl;
+            DEBUG_STREAM << "DataBase::db_get_attribute_alias2(): attribute name "<< row[0] << std::endl;
             strcpy(argout,row[0]);
 		}
 	}
@@ -7667,23 +7667,23 @@ Tango::DevString DataBase::db_get_alias_attribute(Tango::DevString argin)
 	long n_rows=0;
 	argout  = new char[256];
 
-	INFO_STREAM << "DataBase::db_get_alias_attribute(): get " << argin << endl;
+	INFO_STREAM << "DataBase::db_get_alias_attribute(): get " << argin << std::endl;
 
 // first check to see if this alias exists
 
 	sql_query_stream << "SELECT name from attribute_alias WHERE alias LIKE \'" << argin << "\' ";
-	DEBUG_STREAM << "DataBase::db_get_alias_attribute(): sql_query " << sql_query_stream.str() << endl;
+	DEBUG_STREAM << "DataBase::db_get_alias_attribute(): sql_query " << sql_query_stream.str() << std::endl;
 
 	result = query(sql_query_stream.str(),"db_get_alias_attribute()");
 
 	n_rows = mysql_num_rows(result);
-	DEBUG_STREAM << "DataBase::db_get_alias_attribute(): mysql_num_rows() " << n_rows << endl;
+	DEBUG_STREAM << "DataBase::db_get_alias_attribute(): mysql_num_rows() " << n_rows << std::endl;
 
 	if (n_rows > 0)
 	{
         if ((row = mysql_fetch_row(result)) != NULL)
         {
-            DEBUG_STREAM << "DataBase::db_get_alias_attribute(): attribute name "<< row[0] << endl;
+            DEBUG_STREAM << "DataBase::db_get_alias_attribute(): attribute name "<< row[0] << std::endl;
             strcpy(argout,row[0]);
 		}
 	}
@@ -7758,12 +7758,12 @@ void DataBase::db_rename_server(const Tango::DevVarStringArray *argin)
 	long n_rows=0;
 
 	sql_query_stream << "SELECT name from device WHERE name = \'" << new_adm_name << "\' ";
-	DEBUG_STREAM << "DataBase::db_rename_server(): sql_query " << sql_query_stream.str() << endl;
+	DEBUG_STREAM << "DataBase::db_rename_server(): sql_query " << sql_query_stream.str() << std::endl;
 
 	result = query(sql_query_stream.str(),"db_rename_server()");
 
 	n_rows = mysql_num_rows(result);
-	DEBUG_STREAM << "DataBase::db_rename_server(): mysql_num_rows() " << n_rows << endl;
+	DEBUG_STREAM << "DataBase::db_rename_server(): mysql_num_rows() " << n_rows << std::endl;
 
 	if (n_rows > 0)
 	{
@@ -7788,7 +7788,7 @@ void DataBase::db_rename_server(const Tango::DevVarStringArray *argin)
 		{
 			char *tmp_ptr = db_get_device_host((Tango::DevString)adm_dev.c_str());
 			previous_host = tmp_ptr;
-			DEBUG_STREAM << old_name << " was running on " << previous_host << endl;
+			DEBUG_STREAM << old_name << " was running on " << previous_host << std::endl;
 			CORBA::string_free(tmp_ptr);
 		}
 		catch (Tango::DevFailed &e)
@@ -7796,7 +7796,7 @@ void DataBase::db_rename_server(const Tango::DevVarStringArray *argin)
 			string reason(e.errors[0].reason.in());
 			if (reason == DB_DeviceNotDefined)
 			{
-				WARN_STREAM << "DataBase::db_delete_server(): server " << old_name << " not defined in DB" << endl;
+				WARN_STREAM << "DataBase::db_delete_server(): server " << old_name << " not defined in DB" << std::endl;
 				TangoSys_OMemStream o;
 				o << "Server " << old_name << " not defined in database !";
 				Tango::Except::throw_exception((const char *)DB_IncorrectServerName,o.str(),
@@ -7826,7 +7826,7 @@ void DataBase::db_rename_server(const Tango::DevVarStringArray *argin)
 
    		sql_query_stream.str("");
 		sql_query_stream << "UPDATE device set server=\'" << new_name << "\' where server=\'" << old_name << "\'";
-		DEBUG_STREAM << "DataBase::db_rename_server(): sql_query " << sql_query_stream.str() << endl;
+		DEBUG_STREAM << "DataBase::db_rename_server(): sql_query " << sql_query_stream.str() << std::endl;
 
 		simple_query(sql_query_stream.str(),"db_rename_server()",al.get_con_nb());
 
@@ -7835,21 +7835,21 @@ void DataBase::db_rename_server(const Tango::DevVarStringArray *argin)
 		sql_query_stream << "\', family=\'" << new_exec;
 		sql_query_stream << "\', member=\'" << new_inst;
 		sql_query_stream << "\' where name=\'" << old_adm_name << "\'";
-		DEBUG_STREAM << "DataBase::db_rename_server(): sql_query " << sql_query_stream.str() << endl;
+		DEBUG_STREAM << "DataBase::db_rename_server(): sql_query " << sql_query_stream.str() << std::endl;
 
 		simple_query(sql_query_stream.str(),"db_rename_server()",al.get_con_nb());
 
    		sql_query_stream.str("");
 		sql_query_stream << "UPDATE property_device set device=\'" << new_adm_name;
 		sql_query_stream << "\' where device=\'" << old_adm_name << "\'";
-		DEBUG_STREAM << "DataBase::db_rename_server(): sql_query " << sql_query_stream.str() << endl;
+		DEBUG_STREAM << "DataBase::db_rename_server(): sql_query " << sql_query_stream.str() << std::endl;
 
 		simple_query(sql_query_stream.str(),"db_rename_server()",al.get_con_nb());
 
    		sql_query_stream.str("");
 		sql_query_stream << "UPDATE property_attribute_device set device=\'" << new_adm_name;
 		sql_query_stream << "\' where device=\'" << old_adm_name << "\'";
-		DEBUG_STREAM << "DataBase::db_rename_server(): sql_query " << sql_query_stream.str() << endl;
+		DEBUG_STREAM << "DataBase::db_rename_server(): sql_query " << sql_query_stream.str() << std::endl;
 
 		simple_query(sql_query_stream.str(),"db_rename_server()",al.get_con_nb());
 	}
@@ -7899,7 +7899,7 @@ Tango::DevVarStringArray *DataBase::db_get_class_pipe_property(const Tango::DevV
 	//	Add your own code
 
 	const Tango::DevVarStringArray  *property_names = argin;
-	DEBUG_STREAM << "DataBase::db_get_class_pipe_property(): entering... !" << endl;
+	DEBUG_STREAM << "DataBase::db_get_class_pipe_property(): entering... !" << std::endl;
 
 	TangoSys_MemStream sql_query_stream;
 	char n_pipes_str[256];
@@ -7911,7 +7911,7 @@ Tango::DevVarStringArray *DataBase::db_get_class_pipe_property(const Tango::DevV
 	argout = new Tango::DevVarStringArray;
 	const char *tmp_class, *tmp_pipe;
 
-	INFO_STREAM << "DataBase::GetClassPipeProperty(): get properties for " << property_names->length()-1 << " pipe(s) for class " << (*property_names)[0] << endl;
+	INFO_STREAM << "DataBase::GetClassPipeProperty(): get properties for " << property_names->length()-1 << " pipe(s) for class " << (*property_names)[0] << std::endl;
 
 	tmp_class = (*property_names)[0];
 #ifdef TANGO_LONG32
@@ -7931,12 +7931,12 @@ Tango::DevVarStringArray *DataBase::db_get_class_pipe_property(const Tango::DevV
 		sql_query_stream << "SELECT name,value FROM property_pipe_class WHERE class = \""
 		                 << tmp_class << "\" AND pipe LIKE \"" << tmp_pipe
 						 << "\" ORDER BY name,count";
-	   	DEBUG_STREAM << "DataBase::GetClassPipeProperty(): sql_query " << sql_query_stream.str() << endl;
+	   	DEBUG_STREAM << "DataBase::GetClassPipeProperty(): sql_query " << sql_query_stream.str() << std::endl;
 
 		result = query(sql_query_stream.str(),"db_get_class_pipe_property()");
 
 	   	n_rows = mysql_num_rows(result);
-	   	DEBUG_STREAM << "DataBase::GetClassPipeProperty(): mysql_num_rows() " << n_rows << endl;
+	   	DEBUG_STREAM << "DataBase::GetClassPipeProperty(): mysql_num_rows() " << n_rows << std::endl;
 	   	n_props = n_props+2;
 	   	argout->length(n_props);
 	   	(*argout)[n_props-2] = CORBA::string_dup(tmp_pipe);
@@ -7966,7 +7966,7 @@ Tango::DevVarStringArray *DataBase::db_get_class_pipe_property(const Tango::DevV
 						else
 							new_prop = false;
 					}
-//	            			DEBUG_STREAM << "DataBase::GetClassPipeProperty(): property[ "<< i << "] count " << row[0] << " value " << row[1] << endl;
+//	            			DEBUG_STREAM << "DataBase::GetClassPipeProperty(): property[ "<< i << "] count " << row[0] << " value " << row[1] << std::endl;
 					if (new_prop == true)
 					{
 						n_props = n_props + 3;
@@ -8003,7 +8003,7 @@ Tango::DevVarStringArray *DataBase::db_get_class_pipe_property(const Tango::DevV
 	   	mysql_free_result(result);
 	}
 
-	DEBUG_STREAM << "DataBase::GetClassPipeProperty(): argout->length() "<< argout->length() << endl;
+	DEBUG_STREAM << "DataBase::GetClassPipeProperty(): argout->length() "<< argout->length() << std::endl;
 
 	/*----- PROTECTED REGION END -----*/	//	DataBase::db_get_class_pipe_property
 	return argout;
@@ -8049,7 +8049,7 @@ Tango::DevVarStringArray *DataBase::db_get_device_pipe_property(const Tango::Dev
 	TimeVal	before, after;
 	GetTime(before);
 
-	INFO_STREAM << "DataBase::GetDevicePipeProperty(): get properties for " << property_names->length()-1 << " pipe(s) for device " << (*property_names)[0] << endl;
+	INFO_STREAM << "DataBase::GetDevicePipeProperty(): get properties for " << property_names->length()-1 << " pipe(s) for device " << (*property_names)[0] << std::endl;
 
 	tmp_device = (*property_names)[0];
 #ifdef TANGO_LONG32
@@ -8069,11 +8069,11 @@ Tango::DevVarStringArray *DataBase::db_get_device_pipe_property(const Tango::Dev
 
 	bool all_pipe = false;
 	sql_query_stream << "SELECT COUNT(DISTINCT pipe) FROM property_pipe_device WHERE device = \"" << tmp_device << "\"";
-	DEBUG_STREAM << "Database::GetDevicePipeProperty(): sql_query " << sql_query_stream.str() << endl;
+	DEBUG_STREAM << "Database::GetDevicePipeProperty(): sql_query " << sql_query_stream.str() << std::endl;
 
 	result = query(sql_query_stream.str(),"db_get_device_pipe_property()");
 	n_rows = mysql_num_rows(result);
-	DEBUG_STREAM << "DataBase::GetDevicePipeProperty(): mysql_num_rows() " << n_rows << endl;
+	DEBUG_STREAM << "DataBase::GetDevicePipeProperty(): mysql_num_rows() " << n_rows << std::endl;
 
 	if (n_rows != 0)
 	{
@@ -8092,7 +8092,7 @@ Tango::DevVarStringArray *DataBase::db_get_device_pipe_property(const Tango::Dev
 
 	if (all_pipe == true)
 	{
-		DEBUG_STREAM << "DataBase::GetDevicePipeProperty(): Get pipe properties for all pipe(s)" << endl;
+		DEBUG_STREAM << "DataBase::GetDevicePipeProperty(): Get pipe properties for all pipe(s)" << std::endl;
 	}
 
 	if (all_pipe == false)
@@ -8104,12 +8104,12 @@ Tango::DevVarStringArray *DataBase::db_get_device_pipe_property(const Tango::Dev
 			sql_query_stream << "SELECT name,value FROM property_pipe_device WHERE device = \""
 		                 << tmp_device << "\" AND pipe LIKE \"" << tmp_pipe
 						 << "\" ORDER BY name,count";
-	   		DEBUG_STREAM << "DataBase::GetDevicePipeProperty(): sql_query " << sql_query_stream.str() << endl;
+	   		DEBUG_STREAM << "DataBase::GetDevicePipeProperty(): sql_query " << sql_query_stream.str() << std::endl;
 
 			result = query(sql_query_stream.str(),"db_get_device_pipe_property()");
 
 	   		n_rows = mysql_num_rows(result);
-	   		DEBUG_STREAM << "DataBase::GetDevicePipeProperty(): mysql_num_rows() " << n_rows << endl;
+	   		DEBUG_STREAM << "DataBase::GetDevicePipeProperty(): mysql_num_rows() " << n_rows << std::endl;
 	   		n_props = n_props+2;
 	   		argout->length(n_props);
 	   		(*argout)[n_props-2] = CORBA::string_dup(tmp_pipe);
@@ -8139,7 +8139,7 @@ Tango::DevVarStringArray *DataBase::db_get_device_pipe_property(const Tango::Dev
 							else
 								new_prop = false;
 						}
-//	            			DEBUG_STREAM << "DataBase::GetDevicePipeProperty(): property[ "<< i << "] count " << row[0] << " value " << row[1] << endl;
+//	            			DEBUG_STREAM << "DataBase::GetDevicePipeProperty(): property[ "<< i << "] count " << row[0] << " value " << row[1] << std::endl;
 						if (new_prop == true)
 						{
 							n_props = n_props + 3;
@@ -8181,11 +8181,11 @@ Tango::DevVarStringArray *DataBase::db_get_device_pipe_property(const Tango::Dev
 		sql_query_stream.str("");
 		sql_query_stream << "SELECT pipe,name,value FROM property_pipe_device WHERE device = \""
 		                 << tmp_device << "\" ORDER BY pipe,name,count";
-	   	DEBUG_STREAM << "DataBase::GetDevicePipeProperty(): sql_query " << sql_query_stream.str() << endl;
+	   	DEBUG_STREAM << "DataBase::GetDevicePipeProperty(): sql_query " << sql_query_stream.str() << std::endl;
 
 		result = query(sql_query_stream.str(),"db_get_device_pipe_property()");
 		n_rows = mysql_num_rows(result);
-		DEBUG_STREAM << "DataBase::GetDevicePipeProperty(): mysql_num_rows() " << n_rows << endl;
+		DEBUG_STREAM << "DataBase::GetDevicePipeProperty(): mysql_num_rows() " << n_rows << std::endl;
 
 		map<string,vector<PropDef> > db_data;
 
@@ -8313,7 +8313,7 @@ Tango::DevVarStringArray *DataBase::db_get_device_pipe_property(const Tango::Dev
 		}
 	}
 
-	DEBUG_STREAM << "DataBase::GetDevicePipeProperty(): argout->length() "<< argout->length() << endl;
+	DEBUG_STREAM << "DataBase::GetDevicePipeProperty(): argout->length() "<< argout->length() << std::endl;
 
 	GetTime(after);
 	update_timing_stats(before, after, "DbGetDevicePipeProperty");
@@ -8342,7 +8342,7 @@ void DataBase::db_delete_class_pipe(const Tango::DevVarStringArray *argin)
 
 	if (argin->length() < 2) {
    		WARN_STREAM << "DataBase::db_delete_class_pipe(): insufficient number of arguments ";
-   		WARN_STREAM << endl;
+   		WARN_STREAM << std::endl;
    		Tango::Except::throw_exception(DB_IncorrectArguments,
 					       "insufficient number of arguments to delete class pipe",
 					       "DataBase::db_delete_class_pipe()");
@@ -8351,13 +8351,13 @@ void DataBase::db_delete_class_pipe(const Tango::DevVarStringArray *argin)
 	tmp_class = (*argin)[0];
 	pipe = (*argin)[1];
 
-	INFO_STREAM << "DataBase::db_delete_class_pipe(): delete " << tmp_class << " from database" << endl;
+	INFO_STREAM << "DataBase::db_delete_class_pipe(): delete " << tmp_class << " from database" << std::endl;
 
 // then delete class from the property_pipe_class table
 
     sql_query_stream << "DELETE FROM property_pipe_class WHERE class LIKE \"" << tmp_class
 	                 << "\" AND pipe LIKE \"" << pipe << "\" ";
-    DEBUG_STREAM << "DataBase::db_delete_class_pipe(): sql_query " << sql_query_stream.str() << endl;
+    DEBUG_STREAM << "DataBase::db_delete_class_pipe(): sql_query " << sql_query_stream.str() << std::endl;
 	simple_query(sql_query_stream.str(),"db_delete_class_pipe()");
 
 	/*----- PROTECTED REGION END -----*/	//	DataBase::db_delete_class_pipe
@@ -8383,7 +8383,7 @@ void DataBase::db_delete_device_pipe(const Tango::DevVarStringArray *argin)
 
 	if (argin->length() < 2) {
    		WARN_STREAM << "DataBase::db_delete_device_pipe(): insufficient number of arguments ";
-   		WARN_STREAM << endl;
+   		WARN_STREAM << std::endl;
    		Tango::Except::throw_exception(DB_IncorrectArguments,
 					       "insufficient number of arguments to delete device pipe",
 					       "DataBase::db_delete_device_pipe()");
@@ -8392,14 +8392,14 @@ void DataBase::db_delete_device_pipe(const Tango::DevVarStringArray *argin)
 	tmp_device = (*argin)[0].in();
 	pipe = (*argin)[1];
 
-	INFO_STREAM << "DataBase::db_delete_device_pipe(): delete pipe " << pipe << " for device " << tmp_device << " from database" << endl;
+	INFO_STREAM << "DataBase::db_delete_device_pipe(): delete pipe " << pipe << " for device " << tmp_device << " from database" << std::endl;
 
 // first check the device name
 
 	if (!check_device_name(tmp_device))
 	{
          	WARN_STREAM << "DataBase::db_delete_device_pipe(): device name  " << tmp_device << " incorrect ";
-         	WARN_STREAM << endl;
+         	WARN_STREAM << std::endl;
          	Tango::Except::throw_exception(DB_IncorrectDeviceName,
 					       "Failed to delete device pipe, device name incorrect",
 					       "DataBase::db_delete_device_pipe()");
@@ -8413,7 +8413,7 @@ void DataBase::db_delete_device_pipe(const Tango::DevVarStringArray *argin)
 
     sql_query_stream << "DELETE FROM property_pipe_device WHERE device LIKE \""
 	                 << tmp_wildcard << "\" AND pipe LIKE \"" << pipe << "\" ";
-    DEBUG_STREAM << "DataBase::db_delete_device_pipe(): sql_query " << sql_query_stream.str() << endl;
+    DEBUG_STREAM << "DataBase::db_delete_device_pipe(): sql_query " << sql_query_stream.str() << std::endl;
 	simple_query(sql_query_stream.str(),"db_delete_device_pipe()");
 
 	/*----- PROTECTED REGION END -----*/	//	DataBase::db_delete_device_pipe
@@ -8443,7 +8443,7 @@ void DataBase::db_delete_class_pipe_property(const Tango::DevVarStringArray *arg
 
 	if (argin->length() < 3) {
    		WARN_STREAM << "DataBase::db_delete_class_pipe_property(): insufficient number of arguments ";
-   		WARN_STREAM << endl;
+   		WARN_STREAM << std::endl;
    		Tango::Except::throw_exception(DB_IncorrectArguments,
 					       "Insufficient number of arguments to delete class pipe property",
 					       "DataBase::db_delete_class_pipe_property()");
@@ -8460,7 +8460,7 @@ void DataBase::db_delete_class_pipe_property(const Tango::DevVarStringArray *arg
 			property = (*argin)[i+2];
 
 			INFO_STREAM << "DataBase::db_delete_class_pipe_property(): delete class " << tmp_class ;
-			INFO_STREAM << " pipe " << pipe << " property[" << i <<"] " << property << " from database" << endl;
+			INFO_STREAM << " pipe " << pipe << " property[" << i <<"] " << property << " from database" << std::endl;
 
 // Is there something to delete ?
 
@@ -8468,7 +8468,7 @@ void DataBase::db_delete_class_pipe_property(const Tango::DevVarStringArray *arg
 			sql_query_stream << "SELECT count(*) FROM property_pipe_class WHERE class = \"" << tmp_class
 		                	 << "\" AND pipe = \"" << pipe << "\" AND name = \"" << property
 							 << "\" ";
-   			DEBUG_STREAM << "DataBase::db_delete_class_pipe_property(): sql_query " << sql_query_stream.str() << endl;
+   			DEBUG_STREAM << "DataBase::db_delete_class_pipe_property(): sql_query " << sql_query_stream.str() << std::endl;
 			result = query(sql_query_stream.str(),"db_delete_class_pipe_property()",al.get_con_nb());
  	    	row = mysql_fetch_row(result);
 			int count;
@@ -8485,7 +8485,7 @@ void DataBase::db_delete_class_pipe_property(const Tango::DevVarStringArray *arg
 			  sql_query_stream << "DELETE FROM property_pipe_class WHERE class = \"" << tmp_class
 		                	   << "\" AND pipe = \"" << pipe << "\" AND name = \"" << property
 							   << "\" ";
-   			  DEBUG_STREAM << "DataBase::db_delete_class_pipe_property(): sql_query " << sql_query_stream.str() << endl;
+   			  DEBUG_STREAM << "DataBase::db_delete_class_pipe_property(): sql_query " << sql_query_stream.str() << std::endl;
 			  simple_query(sql_query_stream.str(),"db_delete_class_pipe_property()",al.get_con_nb());
 
 // Mark this property as deleted
@@ -8497,7 +8497,7 @@ void DataBase::db_delete_class_pipe_property(const Tango::DevVarStringArray *arg
 													 << "',name='" << property \
 													 << "',id='" << class_pipe_property_hist_id \
 													 << "',count='0',value='DELETED'";
-	    	  DEBUG_STREAM << "DataBase::db_delete_class_pipe_property(): sql_query " << sql_query_stream.str() << endl;
+	    	  DEBUG_STREAM << "DataBase::db_delete_class_pipe_property(): sql_query " << sql_query_stream.str() << std::endl;
 			  simple_query(sql_query_stream.str(),"db_delete_class_pipe_property()",al.get_con_nb());
 
 			}
@@ -8532,7 +8532,7 @@ void DataBase::db_delete_device_pipe_property(const Tango::DevVarStringArray *ar
 
 	if (argin->length() < 3) {
    		WARN_STREAM << "DataBase::db_delete_device_pipe_property(): insufficient number of arguments ";
-   		WARN_STREAM << endl;
+   		WARN_STREAM << std::endl;
    		Tango::Except::throw_exception(DB_IncorrectArguments,
 					       "Insufficient number of arguments to delete device pipe property",
 					       "DataBase::db_delete_device_pipe_property()");
@@ -8542,7 +8542,7 @@ void DataBase::db_delete_device_pipe_property(const Tango::DevVarStringArray *ar
 	if (!check_device_name(tmp_device))
 	{
         	WARN_STREAM << "DataBase::db_delete_device_pipe(): device name  " << tmp_device << " incorrect ";
-         	WARN_STREAM << endl;
+         	WARN_STREAM << std::endl;
          	Tango::Except::throw_exception(DB_IncorrectDeviceName,
 				       	"Failed to delete device pipe, device name incorrect",
 				       	"DataBase::db_delete_device_pipe_property()");
@@ -8558,7 +8558,7 @@ void DataBase::db_delete_device_pipe_property(const Tango::DevVarStringArray *ar
 			property = (*argin)[i+2];
 
 			INFO_STREAM << "DataBase::db_delete_device_pipe_property(): delete device " << tmp_device ;
-			INFO_STREAM << " pipe " << pipe << " property[" << i <<"] " << property << " from database" << endl;
+			INFO_STREAM << " pipe " << pipe << " property[" << i <<"] " << property << " from database" << std::endl;
 
 // Is there something to delete ?
 
@@ -8580,7 +8580,7 @@ void DataBase::db_delete_device_pipe_property(const Tango::DevVarStringArray *ar
 			  sql_query_stream.str("");
 			  sql_query_stream << "DELETE FROM property_pipe_device WHERE device = \"" << tmp_device
 		                	   <<"\" AND pipe = \"" << pipe << "\" AND name = \"" << property << "\" ";
-   			  DEBUG_STREAM << "DataBase::db_delete_device_pipe_property(): sql_query " << sql_query_stream.str() << endl;
+   			  DEBUG_STREAM << "DataBase::db_delete_device_pipe_property(): sql_query " << sql_query_stream.str() << std::endl;
 			  simple_query(sql_query_stream.str(),"db_delete_device_pipe_property()",al.get_con_nb());
 
 // Mark this property as deleted
@@ -8592,7 +8592,7 @@ void DataBase::db_delete_device_pipe_property(const Tango::DevVarStringArray *ar
 							   << "',name='" << property
 							   << "',id='" << device_pipe_property_hist_id
 							   << "',count='0',value='DELETED'";
-	    	  DEBUG_STREAM << "DataBase::DbDeleteDevicePipeProperty(): sql_query " << sql_query_stream.str() << endl;
+	    	  DEBUG_STREAM << "DataBase::DbDeleteDevicePipeProperty(): sql_query " << sql_query_stream.str() << std::endl;
 			  simple_query(sql_query_stream.str(),"db_delete_device_pipe_property()",al.get_con_nb());
 
 			}
@@ -8630,7 +8630,7 @@ Tango::DevVarStringArray *DataBase::db_get_class_pipe_list(const Tango::DevVarSt
 	string tmp_wildcard;
 
 	class_name = (*class_wildcard)[0];
-	INFO_STREAM << "DataBase::db_get_class_pipe_list(): get pipes for class " << class_name << endl;
+	INFO_STREAM << "DataBase::db_get_class_pipe_list(): get pipes for class " << class_name << std::endl;
 
 	wildcard = (*class_wildcard)[1];
 	if (wildcard == NULL)
@@ -8647,12 +8647,12 @@ Tango::DevVarStringArray *DataBase::db_get_class_pipe_list(const Tango::DevVarSt
 		sql_query_stream << "SELECT DISTINCT pipe FROM property_pipe_class WHERE class = \""
 		                 << class_name << "\"  AND pipe like \"" << tmp_wildcard << "\"";
 	}
-	DEBUG_STREAM << "DataBase::DbGetClassPipeList(): sql_query " << sql_query_stream.str() << endl;
+	DEBUG_STREAM << "DataBase::DbGetClassPipeList(): sql_query " << sql_query_stream.str() << std::endl;
 
 	result = query(sql_query_stream.str(),"db_get_class_pipe_list()");
 
 	n_rows = mysql_num_rows(result);
-	DEBUG_STREAM << "DataBase::DbGetClassPipeList(): num_rows() " << n_rows << endl;
+	DEBUG_STREAM << "DataBase::DbGetClassPipeList(): num_rows() " << n_rows << std::endl;
 	if (n_rows > 0)
 	{
 		  int n_pipes=0;
@@ -8660,7 +8660,7 @@ Tango::DevVarStringArray *DataBase::db_get_class_pipe_list(const Tango::DevVarSt
 	      {
 	         if ((row = mysql_fetch_row(result)) != NULL)
 	         {
-	            DEBUG_STREAM << "DataBase::DbGetClassPipeList(): pipe[ "<< j << "] " << row[0] << endl;
+	            DEBUG_STREAM << "DataBase::DbGetClassPipeList(): pipe[ "<< j << "] " << row[0] << std::endl;
 		    	n_pipes++;
 		    	argout->length(n_pipes);
 	            (*argout)[n_pipes-1] = CORBA::string_dup(row[0]);
@@ -8669,7 +8669,7 @@ Tango::DevVarStringArray *DataBase::db_get_class_pipe_list(const Tango::DevVarSt
 	}
 	mysql_free_result(result);
 
-	DEBUG_STREAM << "DataBase::DbGetClassPipeList(): argout->length() "<< argout->length() << endl;
+	DEBUG_STREAM << "DataBase::DbGetClassPipeList(): argout->length() "<< argout->length() << std::endl;
 
 	/*----- PROTECTED REGION END -----*/	//	DataBase::db_get_class_pipe_list
 	return argout;
@@ -8702,7 +8702,7 @@ Tango::DevVarStringArray *DataBase::db_get_device_pipe_list(const Tango::DevVarS
 	device = (*device_wildcard)[0];
 	wildcard = (*device_wildcard)[1];
 	INFO_STREAM << "DataBase::db_get_device_pipe_list(): device " << device;
-	WARN_STREAM << " wildcard " << wildcard << endl;
+	WARN_STREAM << " wildcard " << wildcard << std::endl;
 
 	if (wildcard == NULL)
 	{
@@ -8715,12 +8715,12 @@ Tango::DevVarStringArray *DataBase::db_get_device_pipe_list(const Tango::DevVarS
 		sql_query_stream << "SELECT DISTINCT pipe FROM property_pipe_device WHERE device=\""
 		                 << device << "\" AND pipe LIKE \"" << tmp_wildcard << "\" ORDER BY pipe";
 	}
-	DEBUG_STREAM << "DataBase::db_get_device_attrribute_list(): sql_query " << sql_query_stream.str() << endl;
+	DEBUG_STREAM << "DataBase::db_get_device_attrribute_list(): sql_query " << sql_query_stream.str() << std::endl;
 
 	result = query(sql_query_stream.str(),"db_get_device_pipe_list()");
 
 	n_rows = mysql_num_rows(result);
-	DEBUG_STREAM << "DataBase::db_get_device_pipe_list(): mysql_num_rows() " << n_rows << endl;
+	DEBUG_STREAM << "DataBase::db_get_device_pipe_list(): mysql_num_rows() " << n_rows << std::endl;
 	argout = new Tango::DevVarStringArray;
 
 	if (n_rows > 0)
@@ -8731,7 +8731,7 @@ Tango::DevVarStringArray *DataBase::db_get_device_pipe_list(const Tango::DevVarS
 	   {
 	      if ((row = mysql_fetch_row(result)) != NULL)
 	      {
-	         DEBUG_STREAM << "DataBase::db_get_device_pipe_list(): pipe[ "<< i << "] pipe " << row[0] << endl;
+	         DEBUG_STREAM << "DataBase::db_get_device_pipe_list(): pipe[ "<< i << "] pipe " << row[0] << std::endl;
 	         (*argout)[i]   = CORBA::string_dup(row[0]);
 	      }
 	   }
@@ -8766,7 +8766,7 @@ void DataBase::db_delete_all_device_pipe_property(const Tango::DevVarStringArray
 
 	if (argin->length() < 2) {
    		WARN_STREAM << "DataBase::db_delete_all_device_pipe_property(): insufficient number of arguments ";
-   		WARN_STREAM << endl;
+   		WARN_STREAM << std::endl;
    		Tango::Except::throw_exception(DB_IncorrectArguments,
 					       "Insufficient number of arguments to delete all device pipe(s) property",
 					       "DataBase::db_delete_all_device_pipe_property()");
@@ -8776,7 +8776,7 @@ void DataBase::db_delete_all_device_pipe_property(const Tango::DevVarStringArray
 	if (!check_device_name(tmp_device))
 	{
         	WARN_STREAM << "DataBase::db_delete_all_device_pipe(): device name  " << tmp_device << " incorrect ";
-         	WARN_STREAM << endl;
+         	WARN_STREAM << std::endl;
          	Tango::Except::throw_exception(DB_IncorrectDeviceName,
 				       	"Failed to delete all device pipe(s) property, device name incorrect",
 				       	"DataBase::db_delete_all_device_pipe()");
@@ -8791,7 +8791,7 @@ void DataBase::db_delete_all_device_pipe_property(const Tango::DevVarStringArray
 			pipe = (*argin)[i+1];
 
 			INFO_STREAM << "DataBase::db_delete_all_device_pipe_property(): delete device " << tmp_device ;
-			INFO_STREAM << " pipe " << pipe << " property(ies) from database" << endl;
+			INFO_STREAM << " pipe " << pipe << " property(ies) from database" << std::endl;
 
 // Is there something to delete ?
 
@@ -8809,7 +8809,7 @@ void DataBase::db_delete_all_device_pipe_property(const Tango::DevVarStringArray
 				sql_query_stream.str("");
 				sql_query_stream << "DELETE FROM property_pipe_device WHERE device = \"" << tmp_device
 		       					<<"\" AND pipe = \"" << pipe << "\" ";
-				DEBUG_STREAM << "DataBase::db_delete_all_device_pipe_property(): sql_query " << sql_query_stream.str() << endl;
+				DEBUG_STREAM << "DataBase::db_delete_all_device_pipe_property(): sql_query " << sql_query_stream.str() << std::endl;
 				simple_query(sql_query_stream.str(),"db_delete_all_device_pipe_property()",al.get_con_nb());
 
 // Mark this property as deleted
@@ -8824,7 +8824,7 @@ void DataBase::db_delete_all_device_pipe_property(const Tango::DevVarStringArray
 			   					 << "',name='" << row[0]
 			   					 << "',id='" << device_pipe_property_hist_id
 			   					 << "',count='0',value='DELETED'";
-					DEBUG_STREAM << "DataBase::DeletAllDevicePipeProperty(): sql_query " << sql_query_stream.str() << endl;
+					DEBUG_STREAM << "DataBase::DeletAllDevicePipeProperty(): sql_query " << sql_query_stream.str() << std::endl;
 					simple_query(sql_query_stream.str(),"db_delete_all_device_pipe_property()",al.get_con_nb());
 					purge_pipe_property("property_pipe_device_hist","device",tmp_device.c_str(),pipe,row[0],al.get_con_nb());
 				}
@@ -8862,7 +8862,7 @@ void DataBase::db_put_class_pipe_property(const Tango::DevVarStringArray *argin)
 	const char *tmp_class, *tmp_pipe, *tmp_name;
 
 	sscanf((*argin)[1],"%6d",&n_pipes);
-	INFO_STREAM << "DataBase::PutClasspipeProperty2(): put " << n_pipes << " pipes for device " << (*argin)[0] << endl;
+	INFO_STREAM << "DataBase::PutClasspipeProperty2(): put " << n_pipes << " pipes for device " << (*argin)[0] << std::endl;
 
 	{
 		AutoLock al("LOCK TABLES property_pipe_class WRITE, property_pipe_class_hist WRITE,class_pipe_history_id WRITE",this);
@@ -8885,7 +8885,7 @@ void DataBase::db_put_class_pipe_property(const Tango::DevVarStringArray *argin)
 				sql_query_stream << "DELETE FROM property_pipe_class WHERE class LIKE \""
 			                	 << tmp_class << "\" AND pipe LIKE \"" << tmp_pipe
 								 << "\" AND name LIKE \"" << tmp_name << "\" ";
-	      		DEBUG_STREAM << "DataBase::PutClassPipeProperty(): sql_query " << sql_query_stream.str() << endl;
+	      		DEBUG_STREAM << "DataBase::PutClassPipeProperty(): sql_query " << sql_query_stream.str() << std::endl;
 				simple_query(sql_query_stream.str(),"db_put_class_pipe_property()",al.get_con_nb());
 
 				sscanf((*argin)[j+1], "%6d", &n_rows);
@@ -8904,7 +8904,7 @@ void DataBase::db_put_class_pipe_property(const Tango::DevVarStringArray *argin)
 									 << "\',name=\'" << tmp_name << "\',count=\'" << tmp_count_str
 									 << "\',value=\'" << tmp_escaped_string
 									 << "\',updated=NOW(),accessed=NOW()";
-	      			DEBUG_STREAM << "DataBase::PutClassPipeProperty(): sql_query " << sql_query_stream.str() << endl;
+	      			DEBUG_STREAM << "DataBase::PutClassPipeProperty(): sql_query " << sql_query_stream.str() << std::endl;
 			        simple_query(sql_query_stream.str(),"db_put_class_pipe_property()",al.get_con_nb());
 
 // then insert the new value into the history table
@@ -8915,7 +8915,7 @@ void DataBase::db_put_class_pipe_property(const Tango::DevVarStringArray *argin)
 									 << "\',name=\'" << tmp_name << "\',count=\'" << tmp_count_str
 									 << "\',id=\'" << class_pipe_property_hist_id
 									 << "\',value=\'" << tmp_escaped_string << "\'";
-	      			DEBUG_STREAM << "DataBase::PutClassPipeProperty(): sql_query " << sql_query_stream.str() << endl;
+	      			DEBUG_STREAM << "DataBase::PutClassPipeProperty(): sql_query " << sql_query_stream.str() << std::endl;
 			        simple_query(sql_query_stream.str(),"db_put_class_pipe_property()",al.get_con_nb());
 
 				}
@@ -8959,7 +8959,7 @@ void DataBase::db_put_device_pipe_property(const Tango::DevVarStringArray *argin
 
 
 	sscanf((*argin)[1],"%6d",&n_pipes);
-	INFO_STREAM << "DataBase::DbPutDevicePipeProperty(): put " << n_pipes << " pipes for device " << (*argin)[0] << endl;
+	INFO_STREAM << "DataBase::DbPutDevicePipeProperty(): put " << n_pipes << " pipes for device " << (*argin)[0] << std::endl;
 
 	{
 		AutoLock al("LOCK TABLES property_pipe_device WRITE, property_pipe_device_hist WRITE,device_pipe_history_id WRITE",this);
@@ -8981,7 +8981,7 @@ void DataBase::db_put_device_pipe_property(const Tango::DevVarStringArray *argin
 	      		sql_query_stream << "DELETE FROM property_pipe_device WHERE device LIKE \""
 				                	 << tmp_device << "\" AND pipe LIKE \"" << tmp_pipe
 									 << "\" AND name LIKE \"" << tmp_name << "\" ";
-	      		DEBUG_STREAM << "DataBase::DbPutDevicePipeProperty(): sql_query " << sql_query_stream.str() << endl;
+	      		DEBUG_STREAM << "DataBase::DbPutDevicePipeProperty(): sql_query " << sql_query_stream.str() << std::endl;
 				simple_query(sql_query_stream.str(),"db_put_device_pipe_property()",al.get_con_nb());
 
 				sscanf((*argin)[j+1], "%6d", &n_rows);
@@ -8999,7 +8999,7 @@ void DataBase::db_put_device_pipe_property(const Tango::DevVarStringArray *argin
 					                	 << tmp_device << "\',pipe=\'" << tmp_pipe
 										 << "\',name=\'" << tmp_name << "\',count=\'" << tmp_count_str
 										 << "\',value=\'" << tmp_escaped_string << "\',updated=NOW(),accessed=NOW()";
-	      			DEBUG_STREAM << "DataBase::DbPutDevicePipeProperty(): sql_query " << sql_query_stream.str() << endl;
+	      			DEBUG_STREAM << "DataBase::DbPutDevicePipeProperty(): sql_query " << sql_query_stream.str() << std::endl;
 					simple_query(sql_query_stream.str(),"db_put_device_pipe_property()",al.get_con_nb());
 
 // then insert the new value into the history table
@@ -9009,7 +9009,7 @@ void DataBase::db_put_device_pipe_property(const Tango::DevVarStringArray *argin
 										 << "\',name=\'" << tmp_name << "\',count=\'" << tmp_count_str
 										 << "\',id=\'" << device_pipe_property_hist_id
 										 << "\',value=\'" << tmp_escaped_string << "\'";
-	      			DEBUG_STREAM << "DataBase::DbPutDevicePipeProperty(): sql_query " << sql_query_stream.str() << endl;
+	      			DEBUG_STREAM << "DataBase::DbPutDevicePipeProperty(): sql_query " << sql_query_stream.str() << std::endl;
 					simple_query(sql_query_stream.str(),"db_put_device_pipe_property()",al.get_con_nb());
 
 				}
@@ -9058,7 +9058,7 @@ Tango::DevVarStringArray *DataBase::db_get_class_pipe_property_hist(const Tango:
 
 	if (argin->length() != 3)
 	{
-	   WARN_STREAM << "DataBase::DbGetClassPipePropertyHist(): incorrect number of input arguments " << endl;
+	   WARN_STREAM << "DataBase::DbGetClassPipePropertyHist(): incorrect number of input arguments " << std::endl;
 	   Tango::Except::throw_exception(DB_IncorrectArguments,
 	   				  "Incorrect no. of input arguments, needs 3 (class,pipe,property)",
 					  "DataBase::DbGetClassPipePropertyHist()");
@@ -9160,7 +9160,7 @@ Tango::DevVarStringArray *DataBase::db_get_device_pipe_property_hist(const Tango
 
 	if (argin->length() != 3)
 	{
-	   WARN_STREAM << "DataBase::DbGetDevicePipePropertyHist(): incorrect number of input arguments " << endl;
+	   WARN_STREAM << "DataBase::DbGetDevicePipePropertyHist(): incorrect number of input arguments " << std::endl;
 	   Tango::Except::throw_exception(DB_IncorrectArguments,
 	   				  "Incorrect no. of input arguments, needs 3 (device,pipe,property)",
 					  "DataBase::DbGetDevicePipePropertyHist()");
@@ -9255,7 +9255,7 @@ Tango::DevVarStringArray *DataBase::db_get_forwarded_attribute_list_for_device(T
     MYSQL_RES *result = query(sql_query_stream.str(),"db_get_forwarded_attribute_list_for_device()");
 
     int n_rows = mysql_num_rows(result);
-    DEBUG_STREAM << "DataBase::DbGetForwardedAttributeListForDevice(): mysql_num_rows() " << n_rows << endl;
+    DEBUG_STREAM << "DataBase::DbGetForwardedAttributeListForDevice(): mysql_num_rows() " << n_rows << std::endl;
 	argout = new Tango::DevVarStringArray;
     argout->length(n_rows*3);
 
@@ -9267,7 +9267,7 @@ Tango::DevVarStringArray *DataBase::db_get_forwarded_attribute_list_for_device(T
          if ((row = mysql_fetch_row(result)) != NULL)
          {
             DEBUG_STREAM << "DataBase::DbGetForwardedAttributeListForDevice(): property[ "<< i << "] device " << row[0] <<
-                            " attribute " << row[1] << " __root_att " << row[1] << endl;
+                            " attribute " << row[1] << " __root_att " << row[1] << std::endl;
             (*argout)[3*i]   = CORBA::string_dup(row[0]);
             (*argout)[3*i+1] = CORBA::string_dup(row[1]);
             (*argout)[3*i+2] = CORBA::string_dup(row[2]);
@@ -9314,7 +9314,7 @@ Tango::DevString DataBase::db_get_device_host(Tango::DevString argin,int con_nb)
 	result = query(sql_query_stream.str(),"db_get_device_host()",con_nb);
 
 	n_rows = mysql_num_rows(result);
-	DEBUG_STREAM << "DataBase::db_get_device_host(): mysql_num_rows() " << n_rows << endl;
+	DEBUG_STREAM << "DataBase::db_get_device_host(): mysql_num_rows() " << n_rows << std::endl;
 	Tango::DevString	argout = NULL;
 	if (n_rows > 0)
 	{
@@ -9329,7 +9329,7 @@ Tango::DevString DataBase::db_get_device_host(Tango::DevString argin,int con_nb)
  	    TangoSys_OMemStream o;
 		o << "No host found for device \'" << argin << "\'";
 		string msg = o.str();
-		WARN_STREAM << msg << endl;
+		WARN_STREAM << msg << std::endl;
 		Tango::Except::throw_exception((const char *)DB_DeviceNotDefined,
 	   				                   msg,
 					                   (const char *)"DataBase::db_get_device_host()");
@@ -9366,7 +9366,7 @@ void DataBase::create_update_mem_att(const Tango::DevVarStringArray *argin)
     sql_query_stream << "UPDATE property_attribute_device SET value=\"" << tmp_escaped_string
                      << "\" WHERE device=\"" << tmp_device << "\" AND attribute=\"" << tmp_attribute
                      << "\" AND name=\"__value\" AND count=1";
-    DEBUG_STREAM << "DataBase::PutAttributeProperty2(): sql_query " << sql_query_stream.str() << endl;
+    DEBUG_STREAM << "DataBase::PutAttributeProperty2(): sql_query " << sql_query_stream.str() << std::endl;
 
     int con_nb = get_connection();
 
@@ -9375,12 +9375,12 @@ void DataBase::create_update_mem_att(const Tango::DevVarStringArray *argin)
 	{
 		stringstream o;
 
-		WARN_STREAM << "DataBase::db_put_device_attribute_property2() failed to query TANGO database:" << endl;
-		WARN_STREAM << "  query = " << sql_query << endl;
-		WARN_STREAM << " (SQL error=" << mysql_error(conn_pool[con_nb].db) << ")" << endl;
+		WARN_STREAM << "DataBase::db_put_device_attribute_property2() failed to query TANGO database:" << std::endl;
+		WARN_STREAM << "  query = " << sql_query << std::endl;
+		WARN_STREAM << " (SQL error=" << mysql_error(conn_pool[con_nb].db) << ")" << std::endl;
 
 		o << "Failed to query TANGO database (error=" << mysql_error(conn_pool[con_nb].db) << ")";
-		o << "\n.The query was: " << sql_query << ends;
+		o << "\n.The query was: " << sql_query << std::ends;
 
         release_connection(con_nb);
 
@@ -9400,19 +9400,19 @@ void DataBase::create_update_mem_att(const Tango::DevVarStringArray *argin)
         sql_query_stream << "INSERT INTO property_attribute_device SET device=\'"
                          << tmp_device << "\',attribute=\'" << tmp_attribute
                          << "\',name=\'__value\',count=1,value=\'" << tmp_escaped_string << "\',updated=NOW(),accessed=NOW()";
-        DEBUG_STREAM << "DataBase::PutAttributeProperty(): sql_query " << sql_query_stream.str() << endl;
+        DEBUG_STREAM << "DataBase::PutAttributeProperty(): sql_query " << sql_query_stream.str() << std::endl;
 
         sql_query = sql_query_stream.str();
         if (mysql_real_query(conn_pool[con_nb].db, sql_query.c_str(),sql_query.length()) != 0)
         {
             stringstream o;
 
-            WARN_STREAM << "DataBase::db_put_device_attribute_property2() failed to query TANGO database:" << endl;
-            WARN_STREAM << "  query = " << sql_query << endl;
-            WARN_STREAM << " (SQL error=" << mysql_error(conn_pool[con_nb].db) << ")" << endl;
+            WARN_STREAM << "DataBase::db_put_device_attribute_property2() failed to query TANGO database:" << std::endl;
+            WARN_STREAM << "  query = " << sql_query << std::endl;
+            WARN_STREAM << " (SQL error=" << mysql_error(conn_pool[con_nb].db) << ")" << std::endl;
 
             o << "Failed to query TANGO database (error=" << mysql_error(conn_pool[con_nb].db) << ")";
-            o << "\n.The query was: " << sql_query << ends;
+            o << "\n.The query was: " << sql_query << std::ends;
 
             release_connection(con_nb);
 

--- a/DataBase.cpp
+++ b/DataBase.cpp
@@ -3526,7 +3526,7 @@ Tango::DevVarStringArray *DataBase::db_get_device_attribute_property2(const Tang
 		n_rows = mysql_num_rows(result);
 		DEBUG_STREAM << "DataBase::GetDeviceAttributeProperty2(): mysql_num_rows() " << n_rows << std::endl;
 
-		map<std::string,std::vector<PropDef> > db_data;
+		std::map<std::string,std::vector<PropDef> > db_data;
 
 		std::string att,prev_att;
 		std::string p_name,prev_p_name;
@@ -3608,7 +3608,7 @@ Tango::DevVarStringArray *DataBase::db_get_device_attribute_property2(const Tang
 			std::string tmp_att_lower(tmp_attribute);
 			transform(tmp_att_lower.begin(),tmp_att_lower.end(),tmp_att_lower.begin(),::tolower);
 
-			map<std::string,std::vector<PropDef> >::iterator pos = db_data.find(tmp_att_lower);
+			std::map<std::string,std::vector<PropDef> >::iterator pos = db_data.find(tmp_att_lower);
 
 //
 // Data for this attribute in map?
@@ -8187,7 +8187,7 @@ Tango::DevVarStringArray *DataBase::db_get_device_pipe_property(const Tango::Dev
 		n_rows = mysql_num_rows(result);
 		DEBUG_STREAM << "DataBase::GetDevicePipeProperty(): mysql_num_rows() " << n_rows << std::endl;
 
-		map<std::string,std::vector<PropDef> > db_data;
+		std::map<std::string,std::vector<PropDef> > db_data;
 
 		std::string pipe,prev_pipe;
 		std::string p_name,prev_p_name;
@@ -8269,7 +8269,7 @@ Tango::DevVarStringArray *DataBase::db_get_device_pipe_property(const Tango::Dev
 			std::string tmp_pipe_lower(tmp_pipe);
 			transform(tmp_pipe_lower.begin(),tmp_pipe_lower.end(),tmp_pipe_lower.begin(),::tolower);
 
-			map<std::string,std::vector<PropDef> >::iterator pos = db_data.find(tmp_pipe_lower);
+			std::map<std::string,std::vector<PropDef> >::iterator pos = db_data.find(tmp_pipe_lower);
 
 //
 // Data for this pipe in map?

--- a/DataBase.cpp
+++ b/DataBase.cpp
@@ -197,7 +197,7 @@ bool nocase_compare(char c1, char c2)
  *                implementing the classDataBase
  */
 //--------------------------------------------------------
-DataBase::DataBase(Tango::DeviceClass *cl, string &s)
+DataBase::DataBase(Tango::DeviceClass *cl, std::string &s)
  : TANGO_BASE_CLASS(cl, s.c_str())
 {
 	/*----- PROTECTED REGION ID(DataBase::constructor_1) ENABLED START -----*/
@@ -235,7 +235,7 @@ DataBase::DataBase(Tango::DeviceClass *cl, const char *s, const char *d)
 //--------------------------------------------------------
 void DataBase::delete_device()
 {
-	DEBUG_STREAM << "DataBase::delete_device() " << device_name << endl;
+	DEBUG_STREAM << "DataBase::delete_device() " << device_name << std::endl;
 	/*----- PROTECTED REGION ID(DataBase::delete_device) ENABLED START -----*/
 
 	// Mark the server as non-exported in db
@@ -282,15 +282,15 @@ void DataBase::delete_device()
 //--------------------------------------------------------
 void DataBase::init_device()
 {
-	DEBUG_STREAM << "DataBase::init_device() create device " << device_name << endl;
+	DEBUG_STREAM << "DataBase::init_device() create device " << device_name << std::endl;
 	/*----- PROTECTED REGION ID(DataBase::init_device_before) ENABLED START -----*/
 
 	//	Initialization before get_device_property() call
 
 	/*----- PROTECTED REGION END -----*/	//	DataBase::init_device_before
-
+	
 	//	No device property to be read from database
-
+	
 	/*----- PROTECTED REGION ID(DataBase::init_device) ENABLED START -----*/
 
 //
@@ -481,7 +481,7 @@ void DataBase::init_device()
 //--------------------------------------------------------
 void DataBase::always_executed_hook()
 {
-	DEBUG_STREAM << "DataBase::always_executed_hook()  " << device_name << endl;
+	DEBUG_STREAM << "DataBase::always_executed_hook()  " << device_name << std::endl;
 	/*----- PROTECTED REGION ID(DataBase::always_executed_hook) ENABLED START -----*/
 
 	//	code always executed before all requests
@@ -495,9 +495,9 @@ void DataBase::always_executed_hook()
  *	Description : Hardware acquisition for attributes
  */
 //--------------------------------------------------------
-void DataBase::read_attr_hardware(TANGO_UNUSED(vector<long> &attr_list))
+void DataBase::read_attr_hardware(TANGO_UNUSED(std::vector<long> &attr_list))
 {
-	DEBUG_STREAM << "DataBase::read_attr_hardware(vector<long> &attr_list) entering... " << endl;
+	DEBUG_STREAM << "DataBase::read_attr_hardware(std::vector<long> &attr_list) entering... " << std::endl;
 	/*----- PROTECTED REGION ID(DataBase::read_attr_hardware) ENABLED START -----*/
 
 	//	Add your own code
@@ -509,7 +509,7 @@ void DataBase::read_attr_hardware(TANGO_UNUSED(vector<long> &attr_list))
 //--------------------------------------------------------
 /**
  *	Read attribute StoredProcedureRelease related method
- *	Description:
+ *	Description: 
  *
  *	Data type:	Tango::DevString
  *	Attr type:	Scalar
@@ -517,7 +517,7 @@ void DataBase::read_attr_hardware(TANGO_UNUSED(vector<long> &attr_list))
 //--------------------------------------------------------
 void DataBase::read_StoredProcedureRelease(Tango::Attribute &attr)
 {
-	DEBUG_STREAM << "DataBase::read_StoredProcedureRelease(Tango::Attribute &attr) entering... " << endl;
+	DEBUG_STREAM << "DataBase::read_StoredProcedureRelease(Tango::Attribute &attr) entering... " << std::endl;
 	/*----- PROTECTED REGION ID(DataBase::read_StoredProcedureRelease) ENABLED START -----*/
 	TangoSys_MemStream	sql_query_stream;
 	MYSQL_RES *result;
@@ -569,7 +569,7 @@ void DataBase::read_StoredProcedureRelease(Tango::Attribute &attr)
 //--------------------------------------------------------
 /**
  *	Read attribute Timing_average related method
- *	Description:
+ *	Description: 
  *
  *	Data type:	Tango::DevDouble
  *	Attr type:	Spectrum max = 64
@@ -577,7 +577,7 @@ void DataBase::read_StoredProcedureRelease(Tango::Attribute &attr)
 //--------------------------------------------------------
 void DataBase::read_Timing_average(Tango::Attribute &attr)
 {
-	DEBUG_STREAM << "DataBase::read_Timing_average(Tango::Attribute &attr) entering... " << endl;
+	DEBUG_STREAM << "DataBase::read_Timing_average(Tango::Attribute &attr) entering... " << std::endl;
 	/*----- PROTECTED REGION ID(DataBase::read_Timing_average) ENABLED START -----*/
 	std::map<std::string,TimingStatsStruct*>::iterator iter;
 
@@ -599,7 +599,7 @@ void DataBase::read_Timing_average(Tango::Attribute &attr)
 //--------------------------------------------------------
 /**
  *	Read attribute Timing_minimum related method
- *	Description:
+ *	Description: 
  *
  *	Data type:	Tango::DevDouble
  *	Attr type:	Spectrum max = 64
@@ -607,7 +607,7 @@ void DataBase::read_Timing_average(Tango::Attribute &attr)
 //--------------------------------------------------------
 void DataBase::read_Timing_minimum(Tango::Attribute &attr)
 {
-	DEBUG_STREAM << "DataBase::read_Timing_minimum(Tango::Attribute &attr) entering... " << endl;
+	DEBUG_STREAM << "DataBase::read_Timing_minimum(Tango::Attribute &attr) entering... " << std::endl;
 	/*----- PROTECTED REGION ID(DataBase::read_Timing_minimum) ENABLED START -----*/
 	std::map<std::string,TimingStatsStruct*>::iterator iter;
 
@@ -629,7 +629,7 @@ void DataBase::read_Timing_minimum(Tango::Attribute &attr)
 //--------------------------------------------------------
 /**
  *	Read attribute Timing_maximum related method
- *	Description:
+ *	Description: 
  *
  *	Data type:	Tango::DevDouble
  *	Attr type:	Spectrum max = 64
@@ -637,7 +637,7 @@ void DataBase::read_Timing_minimum(Tango::Attribute &attr)
 //--------------------------------------------------------
 void DataBase::read_Timing_maximum(Tango::Attribute &attr)
 {
-	DEBUG_STREAM << "DataBase::read_Timing_maximum(Tango::Attribute &attr) entering... " << endl;
+	DEBUG_STREAM << "DataBase::read_Timing_maximum(Tango::Attribute &attr) entering... " << std::endl;
 	/*----- PROTECTED REGION ID(DataBase::read_Timing_maximum) ENABLED START -----*/
 	std::map<std::string,TimingStatsStruct*>::iterator iter;
 
@@ -659,7 +659,7 @@ void DataBase::read_Timing_maximum(Tango::Attribute &attr)
 //--------------------------------------------------------
 /**
  *	Read attribute Timing_calls related method
- *	Description:
+ *	Description: 
  *
  *	Data type:	Tango::DevDouble
  *	Attr type:	Spectrum max = 64
@@ -667,7 +667,7 @@ void DataBase::read_Timing_maximum(Tango::Attribute &attr)
 //--------------------------------------------------------
 void DataBase::read_Timing_calls(Tango::Attribute &attr)
 {
-	DEBUG_STREAM << "DataBase::read_Timing_calls(Tango::Attribute &attr) entering... " << endl;
+	DEBUG_STREAM << "DataBase::read_Timing_calls(Tango::Attribute &attr) entering... " << std::endl;
 	/*----- PROTECTED REGION ID(DataBase::read_Timing_calls) ENABLED START -----*/
 	std::map<std::string,TimingStatsStruct*>::iterator iter;
 
@@ -689,7 +689,7 @@ void DataBase::read_Timing_calls(Tango::Attribute &attr)
 //--------------------------------------------------------
 /**
  *	Read attribute Timing_index related method
- *	Description:
+ *	Description: 
  *
  *	Data type:	Tango::DevString
  *	Attr type:	Spectrum max = 64
@@ -697,7 +697,7 @@ void DataBase::read_Timing_calls(Tango::Attribute &attr)
 //--------------------------------------------------------
 void DataBase::read_Timing_index(Tango::Attribute &attr)
 {
-	DEBUG_STREAM << "DataBase::read_Timing_index(Tango::Attribute &attr) entering... " << endl;
+	DEBUG_STREAM << "DataBase::read_Timing_index(Tango::Attribute &attr) entering... " << std::endl;
 	/*----- PROTECTED REGION ID(DataBase::read_Timing_index) ENABLED START -----*/
 	attr.set_value(timing_stats_index, timing_stats_size);
 
@@ -706,7 +706,7 @@ void DataBase::read_Timing_index(Tango::Attribute &attr)
 //--------------------------------------------------------
 /**
  *	Read attribute Timing_info related method
- *	Description:
+ *	Description: 
  *
  *	Data type:	Tango::DevString
  *	Attr type:	Spectrum max = 64
@@ -714,7 +714,7 @@ void DataBase::read_Timing_index(Tango::Attribute &attr)
 //--------------------------------------------------------
 void DataBase::read_Timing_info(Tango::Attribute &attr)
 {
-	DEBUG_STREAM << "DataBase::read_Timing_info(Tango::Attribute &attr) entering... " << endl;
+	DEBUG_STREAM << "DataBase::read_Timing_info(Tango::Attribute &attr) entering... " << std::endl;
 	/*----- PROTECTED REGION ID(DataBase::read_Timing_info) ENABLED START -----*/
 	char info_str[256];
 	char hostname[256];
@@ -775,7 +775,7 @@ void DataBase::add_dynamic_attributes()
 //--------------------------------------------------------
 Tango::DevState DataBase::dev_state()
 {
-	DEBUG_STREAM << "DataBase::State()  - " << device_name << endl;
+	DEBUG_STREAM << "DataBase::State()  - " << device_name << std::endl;
 	/*----- PROTECTED REGION ID(DataBase::dev_state) ENABLED START -----*/
 
 	Tango::DevState	argout = DeviceImpl::dev_state();
@@ -785,7 +785,7 @@ Tango::DevState DataBase::dev_state()
 	/*----- PROTECTED REGION END -----*/	//	DataBase::dev_state
 	set_state(argout);    // Give the state to Tango.
 	if (argout!=Tango::ALARM)
-		DeviceImpl::dev_state();
+		Tango::DeviceImpl::dev_state();
 	return get_state();  // Return it after Tango management.
 }
 //--------------------------------------------------------
@@ -800,7 +800,7 @@ Tango::DevState DataBase::dev_state()
 //--------------------------------------------------------
 void DataBase::db_add_device(const Tango::DevVarStringArray *argin)
 {
-	DEBUG_STREAM << "DataBase::DbAddDevice()  - " << device_name << endl;
+	DEBUG_STREAM << "DataBase::DbAddDevice()  - " << device_name << std::endl;
 	/*----- PROTECTED REGION ID(DataBase::db_add_device) ENABLED START -----*/
 
 	//	Add your own code
@@ -927,7 +927,7 @@ void DataBase::db_add_device(const Tango::DevVarStringArray *argin)
 //--------------------------------------------------------
 void DataBase::db_add_server(const Tango::DevVarStringArray *argin)
 {
-	DEBUG_STREAM << "DataBase::DbAddServer()  - " << device_name << endl;
+	DEBUG_STREAM << "DataBase::DbAddServer()  - " << device_name << std::endl;
 	/*----- PROTECTED REGION ID(DataBase::db_add_server) ENABLED START -----*/
 
 	//	Add your own code
@@ -1025,7 +1025,7 @@ void DataBase::db_add_server(const Tango::DevVarStringArray *argin)
 //--------------------------------------------------------
 void DataBase::db_delete_attribute_alias(Tango::DevString argin)
 {
-	DEBUG_STREAM << "DataBase::DbDeleteAttributeAlias()  - " << device_name << endl;
+	DEBUG_STREAM << "DataBase::DbDeleteAttributeAlias()  - " << device_name << std::endl;
 	/*----- PROTECTED REGION ID(DataBase::db_delete_attribute_alias) ENABLED START -----*/
 
 	//	Add your own code
@@ -1049,7 +1049,7 @@ void DataBase::db_delete_attribute_alias(Tango::DevString argin)
 //--------------------------------------------------------
 void DataBase::db_delete_class_attribute(const Tango::DevVarStringArray *argin)
 {
-	DEBUG_STREAM << "DataBase::DbDeleteClassAttribute()  - " << device_name << endl;
+	DEBUG_STREAM << "DataBase::DbDeleteClassAttribute()  - " << device_name << std::endl;
 	/*----- PROTECTED REGION ID(DataBase::db_delete_class_attribute) ENABLED START -----*/
 
 	//	Add your own code
@@ -1094,7 +1094,7 @@ void DataBase::db_delete_class_attribute(const Tango::DevVarStringArray *argin)
 //--------------------------------------------------------
 void DataBase::db_delete_class_attribute_property(const Tango::DevVarStringArray *argin)
 {
-	DEBUG_STREAM << "DataBase::DbDeleteClassAttributeProperty()  - " << device_name << endl;
+	DEBUG_STREAM << "DataBase::DbDeleteClassAttributeProperty()  - " << device_name << std::endl;
 	/*----- PROTECTED REGION ID(DataBase::db_delete_class_attribute_property) ENABLED START -----*/
 
 	//	Add your own code
@@ -1184,7 +1184,7 @@ void DataBase::db_delete_class_attribute_property(const Tango::DevVarStringArray
 //--------------------------------------------------------
 void DataBase::db_delete_class_property(const Tango::DevVarStringArray *argin)
 {
-	DEBUG_STREAM << "DataBase::DbDeleteClassProperty()  - " << device_name << endl;
+	DEBUG_STREAM << "DataBase::DbDeleteClassProperty()  - " << device_name << std::endl;
 	/*----- PROTECTED REGION ID(DataBase::db_delete_class_property) ENABLED START -----*/
 
 	//	Add your own code
@@ -1259,7 +1259,7 @@ void DataBase::db_delete_class_property(const Tango::DevVarStringArray *argin)
 //--------------------------------------------------------
 void DataBase::db_delete_device(Tango::DevString argin)
 {
-	DEBUG_STREAM << "DataBase::DbDeleteDevice()  - " << device_name << endl;
+	DEBUG_STREAM << "DataBase::DbDeleteDevice()  - " << device_name << std::endl;
 	/*----- PROTECTED REGION ID(DataBase::db_delete_device) ENABLED START -----*/
 
 	//	Add your own code
@@ -1337,7 +1337,7 @@ void DataBase::db_delete_device(Tango::DevString argin)
 //--------------------------------------------------------
 void DataBase::db_delete_device_alias(Tango::DevString argin)
 {
-	DEBUG_STREAM << "DataBase::DbDeleteDeviceAlias()  - " << device_name << endl;
+	DEBUG_STREAM << "DataBase::DbDeleteDeviceAlias()  - " << device_name << std::endl;
 	/*----- PROTECTED REGION ID(DataBase::db_delete_device_alias) ENABLED START -----*/
 
 	//	Add your own code
@@ -1361,7 +1361,7 @@ void DataBase::db_delete_device_alias(Tango::DevString argin)
 //--------------------------------------------------------
 void DataBase::db_delete_device_attribute(const Tango::DevVarStringArray *argin)
 {
-	DEBUG_STREAM << "DataBase::DbDeleteDeviceAttribute()  - " << device_name << endl;
+	DEBUG_STREAM << "DataBase::DbDeleteDeviceAttribute()  - " << device_name << std::endl;
 	/*----- PROTECTED REGION ID(DataBase::db_delete_device_attribute) ENABLED START -----*/
 
 	//	Add your own code
@@ -1421,7 +1421,7 @@ void DataBase::db_delete_device_attribute(const Tango::DevVarStringArray *argin)
 //--------------------------------------------------------
 void DataBase::db_delete_device_attribute_property(const Tango::DevVarStringArray *argin)
 {
-	DEBUG_STREAM << "DataBase::DbDeleteDeviceAttributeProperty()  - " << device_name << endl;
+	DEBUG_STREAM << "DataBase::DbDeleteDeviceAttributeProperty()  - " << device_name << std::endl;
 	/*----- PROTECTED REGION ID(DataBase::db_delete_device_attribute_property) ENABLED START -----*/
 
 	//	Add your own code
@@ -1517,7 +1517,7 @@ void DataBase::db_delete_device_attribute_property(const Tango::DevVarStringArra
 //--------------------------------------------------------
 void DataBase::db_delete_device_property(const Tango::DevVarStringArray *argin)
 {
-	DEBUG_STREAM << "DataBase::DbDeleteDeviceProperty()  - " << device_name << endl;
+	DEBUG_STREAM << "DataBase::DbDeleteDeviceProperty()  - " << device_name << std::endl;
 	/*----- PROTECTED REGION ID(DataBase::db_delete_device_property) ENABLED START -----*/
 
 	//	Add your own code
@@ -1600,7 +1600,7 @@ void DataBase::db_delete_device_property(const Tango::DevVarStringArray *argin)
 //--------------------------------------------------------
 void DataBase::db_delete_property(const Tango::DevVarStringArray *argin)
 {
-	DEBUG_STREAM << "DataBase::DbDeleteProperty()  - " << device_name << endl;
+	DEBUG_STREAM << "DataBase::DbDeleteProperty()  - " << device_name << std::endl;
 	/*----- PROTECTED REGION ID(DataBase::db_delete_property) ENABLED START -----*/
 
 	//	Add your own code
@@ -1678,7 +1678,7 @@ void DataBase::db_delete_property(const Tango::DevVarStringArray *argin)
 //--------------------------------------------------------
 void DataBase::db_delete_server(Tango::DevString argin)
 {
-	DEBUG_STREAM << "DataBase::DbDeleteServer()  - " << device_name << endl;
+	DEBUG_STREAM << "DataBase::DbDeleteServer()  - " << device_name << std::endl;
 	/*----- PROTECTED REGION ID(DataBase::db_delete_server) ENABLED START -----*/
 
 	//	Add your own code
@@ -1798,7 +1798,7 @@ void DataBase::db_delete_server(Tango::DevString argin)
 //--------------------------------------------------------
 void DataBase::db_delete_server_info(Tango::DevString argin)
 {
-	DEBUG_STREAM << "DataBase::DbDeleteServerInfo()  - " << device_name << endl;
+	DEBUG_STREAM << "DataBase::DbDeleteServerInfo()  - " << device_name << std::endl;
 	/*----- PROTECTED REGION ID(DataBase::db_delete_server_info) ENABLED START -----*/
 
 	//	Add your own code
@@ -1832,7 +1832,7 @@ void DataBase::db_delete_server_info(Tango::DevString argin)
 //--------------------------------------------------------
 void DataBase::db_export_device(const Tango::DevVarStringArray *argin)
 {
-	DEBUG_STREAM << "DataBase::DbExportDevice()  - " << device_name << endl;
+	DEBUG_STREAM << "DataBase::DbExportDevice()  - " << device_name << std::endl;
 	/*----- PROTECTED REGION ID(DataBase::db_export_device) ENABLED START -----*/
 
 	//	Add your own code
@@ -1990,7 +1990,7 @@ void DataBase::db_export_device(const Tango::DevVarStringArray *argin)
 //--------------------------------------------------------
 void DataBase::db_export_event(const Tango::DevVarStringArray *argin)
 {
-	DEBUG_STREAM << "DataBase::DbExportEvent()  - " << device_name << endl;
+	DEBUG_STREAM << "DataBase::DbExportEvent()  - " << device_name << std::endl;
 	/*----- PROTECTED REGION ID(DataBase::db_export_event) ENABLED START -----*/
 
 	//	Add your own code
@@ -2058,7 +2058,7 @@ void DataBase::db_export_event(const Tango::DevVarStringArray *argin)
 Tango::DevString DataBase::db_get_alias_device(Tango::DevString argin)
 {
 	Tango::DevString argout;
-	DEBUG_STREAM << "DataBase::DbGetAliasDevice()  - " << device_name << endl;
+	DEBUG_STREAM << "DataBase::DbGetAliasDevice()  - " << device_name << std::endl;
 	/*----- PROTECTED REGION ID(DataBase::db_get_alias_device) ENABLED START -----*/
 
 	//	Add your own code
@@ -2121,7 +2121,7 @@ Tango::DevString DataBase::db_get_alias_device(Tango::DevString argin)
 Tango::DevString DataBase::db_get_attribute_alias(Tango::DevString argin)
 {
 	Tango::DevString argout;
-	DEBUG_STREAM << "DataBase::DbGetAttributeAlias()  - " << device_name << endl;
+	DEBUG_STREAM << "DataBase::DbGetAttributeAlias()  - " << device_name << std::endl;
 	/*----- PROTECTED REGION ID(DataBase::db_get_attribute_alias) ENABLED START -----*/
 
 	//	Add your own code
@@ -2181,7 +2181,7 @@ Tango::DevString DataBase::db_get_attribute_alias(Tango::DevString argin)
 Tango::DevVarStringArray *DataBase::db_get_attribute_alias_list(Tango::DevString argin)
 {
 	Tango::DevVarStringArray *argout;
-	DEBUG_STREAM << "DataBase::DbGetAttributeAliasList()  - " << device_name << endl;
+	DEBUG_STREAM << "DataBase::DbGetAttributeAliasList()  - " << device_name << std::endl;
 	/*----- PROTECTED REGION ID(DataBase::db_get_attribute_alias_list) ENABLED START -----*/
 
 	//	Add your own code
@@ -2246,7 +2246,7 @@ Tango::DevVarStringArray *DataBase::db_get_attribute_alias_list(Tango::DevString
 Tango::DevVarStringArray *DataBase::db_get_class_attribute_list(const Tango::DevVarStringArray *argin)
 {
 	Tango::DevVarStringArray *argout;
-	DEBUG_STREAM << "DataBase::DbGetClassAttributeList()  - " << device_name << endl;
+	DEBUG_STREAM << "DataBase::DbGetClassAttributeList()  - " << device_name << std::endl;
 	/*----- PROTECTED REGION ID(DataBase::db_get_class_attribute_list) ENABLED START -----*/
 
 	//	Add your own code
@@ -2323,7 +2323,7 @@ Tango::DevVarStringArray *DataBase::db_get_class_attribute_list(const Tango::Dev
 Tango::DevVarStringArray *DataBase::db_get_class_attribute_property(const Tango::DevVarStringArray *argin)
 {
 	Tango::DevVarStringArray *argout;
-	DEBUG_STREAM << "DataBase::DbGetClassAttributeProperty()  - " << device_name << endl;
+	DEBUG_STREAM << "DataBase::DbGetClassAttributeProperty()  - " << device_name << std::endl;
 	/*----- PROTECTED REGION ID(DataBase::db_get_class_attribute_property) ENABLED START -----*/
 
 	//	Add your own code
@@ -2415,7 +2415,7 @@ Tango::DevVarStringArray *DataBase::db_get_class_attribute_property(const Tango:
 Tango::DevVarStringArray *DataBase::db_get_class_attribute_property2(const Tango::DevVarStringArray *argin)
 {
 	Tango::DevVarStringArray *argout;
-	DEBUG_STREAM << "DataBase::DbGetClassAttributeProperty2()  - " << device_name << endl;
+	DEBUG_STREAM << "DataBase::DbGetClassAttributeProperty2()  - " << device_name << std::endl;
 	/*----- PROTECTED REGION ID(DataBase::db_get_class_attribute_property2) ENABLED START -----*/
 
 	//	Add your own code
@@ -2555,7 +2555,7 @@ Tango::DevVarStringArray *DataBase::db_get_class_attribute_property2(const Tango
 Tango::DevVarStringArray *DataBase::db_get_class_attribute_property_hist(const Tango::DevVarStringArray *argin)
 {
 	Tango::DevVarStringArray *argout;
-	DEBUG_STREAM << "DataBase::DbGetClassAttributePropertyHist()  - " << device_name << endl;
+	DEBUG_STREAM << "DataBase::DbGetClassAttributePropertyHist()  - " << device_name << std::endl;
 	/*----- PROTECTED REGION ID(DataBase::db_get_class_attribute_property_hist) ENABLED START -----*/
 
 	//	Add your own code
@@ -2650,7 +2650,7 @@ Tango::DevVarStringArray *DataBase::db_get_class_attribute_property_hist(const T
 Tango::DevString DataBase::db_get_class_for_device(Tango::DevString argin)
 {
 	Tango::DevString argout;
-	DEBUG_STREAM << "DataBase::DbGetClassForDevice()  - " << device_name << endl;
+	DEBUG_STREAM << "DataBase::DbGetClassForDevice()  - " << device_name << std::endl;
 	/*----- PROTECTED REGION ID(DataBase::db_get_class_for_device) ENABLED START -----*/
 
 	//	Add your own code
@@ -2705,7 +2705,7 @@ Tango::DevString DataBase::db_get_class_for_device(Tango::DevString argin)
 Tango::DevVarStringArray *DataBase::db_get_class_inheritance_for_device(Tango::DevString argin)
 {
 	Tango::DevVarStringArray *argout;
-	DEBUG_STREAM << "DataBase::DbGetClassInheritanceForDevice()  - " << device_name << endl;
+	DEBUG_STREAM << "DataBase::DbGetClassInheritanceForDevice()  - " << device_name << std::endl;
 	/*----- PROTECTED REGION ID(DataBase::db_get_class_inheritance_for_device) ENABLED START -----*/
 
 	//	Add your own code
@@ -2744,7 +2744,7 @@ Tango::DevVarStringArray *DataBase::db_get_class_inheritance_for_device(Tango::D
 Tango::DevVarStringArray *DataBase::db_get_class_list(Tango::DevString argin)
 {
 	Tango::DevVarStringArray *argout;
-	DEBUG_STREAM << "DataBase::DbGetClassList()  - " << device_name << endl;
+	DEBUG_STREAM << "DataBase::DbGetClassList()  - " << device_name << std::endl;
 	/*----- PROTECTED REGION ID(DataBase::db_get_class_list) ENABLED START -----*/
 
 	//	Add your own code
@@ -2791,7 +2791,7 @@ Tango::DevVarStringArray *DataBase::db_get_class_list(Tango::DevString argin)
 //--------------------------------------------------------
 /**
  *	Command DbGetClassProperty related method
- *	Description:
+ *	Description: 
  *
  *	@param argin Str[0] = Tango class
  *               Str[1] = Property name
@@ -2808,7 +2808,7 @@ Tango::DevVarStringArray *DataBase::db_get_class_list(Tango::DevString argin)
 Tango::DevVarStringArray *DataBase::db_get_class_property(const Tango::DevVarStringArray *argin)
 {
 	Tango::DevVarStringArray *argout;
-	DEBUG_STREAM << "DataBase::DbGetClassProperty()  - " << device_name << endl;
+	DEBUG_STREAM << "DataBase::DbGetClassProperty()  - " << device_name << std::endl;
 	/*----- PROTECTED REGION ID(DataBase::db_get_class_property) ENABLED START -----*/
 
 	//	Add your own code
@@ -2891,7 +2891,7 @@ Tango::DevVarStringArray *DataBase::db_get_class_property(const Tango::DevVarStr
 Tango::DevVarStringArray *DataBase::db_get_class_property_hist(const Tango::DevVarStringArray *argin)
 {
 	Tango::DevVarStringArray *argout;
-	DEBUG_STREAM << "DataBase::DbGetClassPropertyHist()  - " << device_name << endl;
+	DEBUG_STREAM << "DataBase::DbGetClassPropertyHist()  - " << device_name << std::endl;
 	/*----- PROTECTED REGION ID(DataBase::db_get_class_property_hist) ENABLED START -----*/
 
 	//	Add your own code
@@ -2982,7 +2982,7 @@ Tango::DevVarStringArray *DataBase::db_get_class_property_hist(const Tango::DevV
 Tango::DevVarStringArray *DataBase::db_get_class_property_list(Tango::DevString argin)
 {
 	Tango::DevVarStringArray *argout;
-	DEBUG_STREAM << "DataBase::DbGetClassPropertyList()  - " << device_name << endl;
+	DEBUG_STREAM << "DataBase::DbGetClassPropertyList()  - " << device_name << std::endl;
 	/*----- PROTECTED REGION ID(DataBase::db_get_class_property_list) ENABLED START -----*/
 
 	//	Add your own code
@@ -3050,7 +3050,7 @@ Tango::DevVarStringArray *DataBase::db_get_class_property_list(Tango::DevString 
 Tango::DevString DataBase::db_get_device_alias(Tango::DevString argin)
 {
 	Tango::DevString argout;
-	DEBUG_STREAM << "DataBase::DbGetDeviceAlias()  - " << device_name << endl;
+	DEBUG_STREAM << "DataBase::DbGetDeviceAlias()  - " << device_name << std::endl;
 	/*----- PROTECTED REGION ID(DataBase::db_get_device_alias) ENABLED START -----*/
 
 	//	Add your own code
@@ -3130,7 +3130,7 @@ Tango::DevString DataBase::db_get_device_alias(Tango::DevString argin)
 Tango::DevVarStringArray *DataBase::db_get_device_alias_list(Tango::DevString argin)
 {
 	Tango::DevVarStringArray *argout;
-	DEBUG_STREAM << "DataBase::DbGetDeviceAliasList()  - " << device_name << endl;
+	DEBUG_STREAM << "DataBase::DbGetDeviceAliasList()  - " << device_name << std::endl;
 	/*----- PROTECTED REGION ID(DataBase::db_get_device_alias_list) ENABLED START -----*/
 
 	//	Add your own code
@@ -3195,7 +3195,7 @@ Tango::DevVarStringArray *DataBase::db_get_device_alias_list(Tango::DevString ar
 Tango::DevVarStringArray *DataBase::db_get_device_attribute_list(const Tango::DevVarStringArray *argin)
 {
 	Tango::DevVarStringArray *argout;
-	DEBUG_STREAM << "DataBase::DbGetDeviceAttributeList()  - " << device_name << endl;
+	DEBUG_STREAM << "DataBase::DbGetDeviceAttributeList()  - " << device_name << std::endl;
 	/*----- PROTECTED REGION ID(DataBase::db_get_device_attribute_list) ENABLED START -----*/
 
 	//	Add your own code
@@ -3270,7 +3270,7 @@ Tango::DevVarStringArray *DataBase::db_get_device_attribute_list(const Tango::De
 Tango::DevVarStringArray *DataBase::db_get_device_attribute_property(const Tango::DevVarStringArray *argin)
 {
 	Tango::DevVarStringArray *argout;
-	DEBUG_STREAM << "DataBase::DbGetDeviceAttributeProperty()  - " << device_name << endl;
+	DEBUG_STREAM << "DataBase::DbGetDeviceAttributeProperty()  - " << device_name << std::endl;
 	/*----- PROTECTED REGION ID(DataBase::db_get_device_attribute_property) ENABLED START -----*/
 
 	//	Add your own code
@@ -3370,7 +3370,7 @@ Tango::DevVarStringArray *DataBase::db_get_device_attribute_property(const Tango
 Tango::DevVarStringArray *DataBase::db_get_device_attribute_property2(const Tango::DevVarStringArray *argin)
 {
 	Tango::DevVarStringArray *argout;
-	DEBUG_STREAM << "DataBase::DbGetDeviceAttributeProperty2()  - " << device_name << endl;
+	DEBUG_STREAM << "DataBase::DbGetDeviceAttributeProperty2()  - " << device_name << std::endl;
 	/*----- PROTECTED REGION ID(DataBase::db_get_device_attribute_property2) ENABLED START -----*/
 
 	//	Add your own code
@@ -3679,7 +3679,7 @@ Tango::DevVarStringArray *DataBase::db_get_device_attribute_property2(const Tang
 Tango::DevVarStringArray *DataBase::db_get_device_attribute_property_hist(const Tango::DevVarStringArray *argin)
 {
 	Tango::DevVarStringArray *argout;
-	DEBUG_STREAM << "DataBase::DbGetDeviceAttributePropertyHist()  - " << device_name << endl;
+	DEBUG_STREAM << "DataBase::DbGetDeviceAttributePropertyHist()  - " << device_name << std::endl;
 	/*----- PROTECTED REGION ID(DataBase::db_get_device_attribute_property_hist) ENABLED START -----*/
 
 	//	Add your own code
@@ -3777,7 +3777,7 @@ Tango::DevVarStringArray *DataBase::db_get_device_attribute_property_hist(const 
 Tango::DevVarStringArray *DataBase::db_get_device_class_list(Tango::DevString argin)
 {
 	Tango::DevVarStringArray *argout;
-	DEBUG_STREAM << "DataBase::DbGetDeviceClassList()  - " << device_name << endl;
+	DEBUG_STREAM << "DataBase::DbGetDeviceClassList()  - " << device_name << std::endl;
 	/*----- PROTECTED REGION ID(DataBase::db_get_device_class_list) ENABLED START -----*/
 
 	//	Add your own code
@@ -3839,7 +3839,7 @@ Tango::DevVarStringArray *DataBase::db_get_device_class_list(Tango::DevString ar
 Tango::DevVarStringArray *DataBase::db_get_device_domain_list(Tango::DevString argin)
 {
 	Tango::DevVarStringArray *argout;
-	DEBUG_STREAM << "DataBase::DbGetDeviceDomainList()  - " << device_name << endl;
+	DEBUG_STREAM << "DataBase::DbGetDeviceDomainList()  - " << device_name << std::endl;
 	/*----- PROTECTED REGION ID(DataBase::db_get_device_domain_list) ENABLED START -----*/
 
 	//	Add your own code
@@ -3908,7 +3908,7 @@ Tango::DevVarStringArray *DataBase::db_get_device_domain_list(Tango::DevString a
 Tango::DevVarStringArray *DataBase::db_get_device_exported_list(Tango::DevString argin)
 {
 	Tango::DevVarStringArray *argout;
-	DEBUG_STREAM << "DataBase::DbGetDeviceExportedList()  - " << device_name << endl;
+	DEBUG_STREAM << "DataBase::DbGetDeviceExportedList()  - " << device_name << std::endl;
 	/*----- PROTECTED REGION ID(DataBase::db_get_device_exported_list) ENABLED START -----*/
 
 	//	Add your own code
@@ -3979,7 +3979,7 @@ Tango::DevVarStringArray *DataBase::db_get_device_exported_list(Tango::DevString
 Tango::DevVarStringArray *DataBase::db_get_device_family_list(Tango::DevString argin)
 {
 	Tango::DevVarStringArray *argout;
-	DEBUG_STREAM << "DataBase::DbGetDeviceFamilyList()  - " << device_name << endl;
+	DEBUG_STREAM << "DataBase::DbGetDeviceFamilyList()  - " << device_name << std::endl;
 	/*----- PROTECTED REGION ID(DataBase::db_get_device_family_list) ENABLED START -----*/
 
 	//	Add your own code
@@ -4051,7 +4051,7 @@ Tango::DevVarStringArray *DataBase::db_get_device_family_list(Tango::DevString a
  *           Str[5] = Started date (or ? if not set)
  *           Str[6] = Stopped date (or ? if not set)
  *           Str[7] = Device class
- *
+ *           
  *           Lg[0] = Device exported flag
  *           Lg[1] = Device Server process PID (or -1 if not set)
  */
@@ -4059,7 +4059,7 @@ Tango::DevVarStringArray *DataBase::db_get_device_family_list(Tango::DevString a
 Tango::DevVarLongStringArray *DataBase::db_get_device_info(Tango::DevString argin)
 {
 	Tango::DevVarLongStringArray *argout;
-	DEBUG_STREAM << "DataBase::DbGetDeviceInfo()  - " << device_name << endl;
+	DEBUG_STREAM << "DataBase::DbGetDeviceInfo()  - " << device_name << std::endl;
 	/*----- PROTECTED REGION ID(DataBase::db_get_device_info) ENABLED START -----*/
 
 	//	Add your own code
@@ -4196,7 +4196,7 @@ Tango::DevVarLongStringArray *DataBase::db_get_device_info(Tango::DevString argi
 Tango::DevVarStringArray *DataBase::db_get_device_list(const Tango::DevVarStringArray *argin)
 {
 	Tango::DevVarStringArray *argout;
-	DEBUG_STREAM << "DataBase::DbGetDeviceList()  - " << device_name << endl;
+	DEBUG_STREAM << "DataBase::DbGetDeviceList()  - " << device_name << std::endl;
 	/*----- PROTECTED REGION ID(DataBase::db_get_device_list) ENABLED START -----*/
 
 	//	Add your own code
@@ -4263,7 +4263,7 @@ Tango::DevVarStringArray *DataBase::db_get_device_list(const Tango::DevVarString
 Tango::DevVarStringArray *DataBase::db_get_device_wide_list(Tango::DevString argin)
 {
 	Tango::DevVarStringArray *argout;
-	DEBUG_STREAM << "DataBase::DbGetDeviceWideList()  - " << device_name << endl;
+	DEBUG_STREAM << "DataBase::DbGetDeviceWideList()  - " << device_name << std::endl;
 	/*----- PROTECTED REGION ID(DataBase::db_get_device_wide_list) ENABLED START -----*/
 
 	//	Add your own code
@@ -4332,7 +4332,7 @@ Tango::DevVarStringArray *DataBase::db_get_device_wide_list(Tango::DevString arg
 Tango::DevVarStringArray *DataBase::db_get_device_member_list(Tango::DevString argin)
 {
 	Tango::DevVarStringArray *argout;
-	DEBUG_STREAM << "DataBase::DbGetDeviceMemberList()  - " << device_name << endl;
+	DEBUG_STREAM << "DataBase::DbGetDeviceMemberList()  - " << device_name << std::endl;
 	/*----- PROTECTED REGION ID(DataBase::db_get_device_member_list) ENABLED START -----*/
 
 	//	Add your own code
@@ -4393,7 +4393,7 @@ Tango::DevVarStringArray *DataBase::db_get_device_member_list(Tango::DevString a
 //--------------------------------------------------------
 /**
  *	Command DbGetDeviceProperty related method
- *	Description:
+ *	Description: 
  *
  *	@param argin Str[0] = Device name
  *               Str[1] = Property name
@@ -4413,7 +4413,7 @@ Tango::DevVarStringArray *DataBase::db_get_device_member_list(Tango::DevString a
 Tango::DevVarStringArray *DataBase::db_get_device_property(const Tango::DevVarStringArray *argin)
 {
 	Tango::DevVarStringArray *argout;
-	DEBUG_STREAM << "DataBase::DbGetDeviceProperty()  - " << device_name << endl;
+	DEBUG_STREAM << "DataBase::DbGetDeviceProperty()  - " << device_name << std::endl;
 	/*----- PROTECTED REGION ID(DataBase::db_get_device_property) ENABLED START -----*/
 
 	//	Add your own code
@@ -4520,7 +4520,7 @@ Tango::DevVarStringArray *DataBase::db_get_device_property(const Tango::DevVarSt
 Tango::DevVarStringArray *DataBase::db_get_device_property_hist(const Tango::DevVarStringArray *argin)
 {
 	Tango::DevVarStringArray *argout;
-	DEBUG_STREAM << "DataBase::DbGetDevicePropertyHist()  - " << device_name << endl;
+	DEBUG_STREAM << "DataBase::DbGetDevicePropertyHist()  - " << device_name << std::endl;
 	/*----- PROTECTED REGION ID(DataBase::db_get_device_property_hist) ENABLED START -----*/
 
 	//	Add your own code
@@ -4613,7 +4613,7 @@ Tango::DevVarStringArray *DataBase::db_get_device_property_hist(const Tango::Dev
 Tango::DevVarStringArray *DataBase::db_get_device_property_list(const Tango::DevVarStringArray *argin)
 {
 	Tango::DevVarStringArray *argout;
-	DEBUG_STREAM << "DataBase::DbGetDevicePropertyList()  - " << device_name << endl;
+	DEBUG_STREAM << "DataBase::DbGetDevicePropertyList()  - " << device_name << std::endl;
 	/*----- PROTECTED REGION ID(DataBase::db_get_device_property_list) ENABLED START -----*/
 
 	//	Add your own code
@@ -4688,7 +4688,7 @@ Tango::DevVarStringArray *DataBase::db_get_device_property_list(const Tango::Dev
 Tango::DevVarStringArray *DataBase::db_get_device_server_class_list(Tango::DevString argin)
 {
 	Tango::DevVarStringArray *argout;
-	DEBUG_STREAM << "DataBase::DbGetDeviceServerClassList()  - " << device_name << endl;
+	DEBUG_STREAM << "DataBase::DbGetDeviceServerClassList()  - " << device_name << std::endl;
 	/*----- PROTECTED REGION ID(DataBase::db_get_device_server_class_list) ENABLED START -----*/
 
 	//	Add your own code
@@ -4744,7 +4744,7 @@ Tango::DevVarStringArray *DataBase::db_get_device_server_class_list(Tango::DevSt
 Tango::DevVarStringArray *DataBase::db_get_exportd_device_list_for_class(Tango::DevString argin)
 {
 	Tango::DevVarStringArray *argout;
-	DEBUG_STREAM << "DataBase::DbGetExportdDeviceListForClass()  - " << device_name << endl;
+	DEBUG_STREAM << "DataBase::DbGetExportdDeviceListForClass()  - " << device_name << std::endl;
 	/*----- PROTECTED REGION ID(DataBase::db_get_exportd_device_list_for_class) ENABLED START -----*/
 
 	//	Add your own code
@@ -4807,7 +4807,7 @@ Tango::DevVarStringArray *DataBase::db_get_exportd_device_list_for_class(Tango::
 Tango::DevVarStringArray *DataBase::db_get_host_list(Tango::DevString argin)
 {
 	Tango::DevVarStringArray *argout;
-	DEBUG_STREAM << "DataBase::DbGetHostList()  - " << device_name << endl;
+	DEBUG_STREAM << "DataBase::DbGetHostList()  - " << device_name << std::endl;
 	/*----- PROTECTED REGION ID(DataBase::db_get_host_list) ENABLED START -----*/
 
 	//	Add your own code
@@ -4878,7 +4878,7 @@ Tango::DevVarStringArray *DataBase::db_get_host_list(Tango::DevString argin)
 Tango::DevVarStringArray *DataBase::db_get_host_server_list(Tango::DevString argin)
 {
 	Tango::DevVarStringArray *argout;
-	DEBUG_STREAM << "DataBase::DbGetHostServerList()  - " << device_name << endl;
+	DEBUG_STREAM << "DataBase::DbGetHostServerList()  - " << device_name << std::endl;
 	/*----- PROTECTED REGION ID(DataBase::db_get_host_server_list) ENABLED START -----*/
 
 	//	Add your own code
@@ -4949,7 +4949,7 @@ Tango::DevVarStringArray *DataBase::db_get_host_server_list(Tango::DevString arg
 Tango::DevVarStringArray *DataBase::db_get_host_servers_info(Tango::DevString argin)
 {
 	Tango::DevVarStringArray *argout;
-	DEBUG_STREAM << "DataBase::DbGetHostServersInfo()  - " << device_name << endl;
+	DEBUG_STREAM << "DataBase::DbGetHostServersInfo()  - " << device_name << std::endl;
 	/*----- PROTECTED REGION ID(DataBase::db_get_host_servers_info) ENABLED START -----*/
 
 	//	Add your own code
@@ -4992,7 +4992,7 @@ Tango::DevVarStringArray *DataBase::db_get_host_servers_info(Tango::DevString ar
 Tango::DevVarStringArray *DataBase::db_get_instance_name_list(Tango::DevString argin)
 {
 	Tango::DevVarStringArray *argout;
-	DEBUG_STREAM << "DataBase::DbGetInstanceNameList()  - " << device_name << endl;
+	DEBUG_STREAM << "DataBase::DbGetInstanceNameList()  - " << device_name << std::endl;
 	/*----- PROTECTED REGION ID(DataBase::db_get_instance_name_list) ENABLED START -----*/
 
 	//	Add your own code
@@ -5042,7 +5042,7 @@ Tango::DevVarStringArray *DataBase::db_get_instance_name_list(Tango::DevString a
 Tango::DevVarStringArray *DataBase::db_get_object_list(Tango::DevString argin)
 {
 	Tango::DevVarStringArray *argout;
-	DEBUG_STREAM << "DataBase::DbGetObjectList()  - " << device_name << endl;
+	DEBUG_STREAM << "DataBase::DbGetObjectList()  - " << device_name << std::endl;
 	/*----- PROTECTED REGION ID(DataBase::db_get_object_list) ENABLED START -----*/
 
 	//	Add your own code
@@ -5110,7 +5110,7 @@ Tango::DevVarStringArray *DataBase::db_get_object_list(Tango::DevString argin)
 Tango::DevVarStringArray *DataBase::db_get_property(const Tango::DevVarStringArray *argin)
 {
 	Tango::DevVarStringArray *argout;
-	DEBUG_STREAM << "DataBase::DbGetProperty()  - " << device_name << endl;
+	DEBUG_STREAM << "DataBase::DbGetProperty()  - " << device_name << std::endl;
 	/*----- PROTECTED REGION ID(DataBase::db_get_property) ENABLED START -----*/
 
 	//	Add your own code
@@ -5199,7 +5199,7 @@ Tango::DevVarStringArray *DataBase::db_get_property(const Tango::DevVarStringArr
 Tango::DevVarStringArray *DataBase::db_get_property_hist(const Tango::DevVarStringArray *argin)
 {
 	Tango::DevVarStringArray *argout;
-	DEBUG_STREAM << "DataBase::DbGetPropertyHist()  - " << device_name << endl;
+	DEBUG_STREAM << "DataBase::DbGetPropertyHist()  - " << device_name << std::endl;
 	/*----- PROTECTED REGION ID(DataBase::db_get_property_hist) ENABLED START -----*/
 
 	//	Add your own code
@@ -5292,7 +5292,7 @@ Tango::DevVarStringArray *DataBase::db_get_property_hist(const Tango::DevVarStri
 Tango::DevVarStringArray *DataBase::db_get_property_list(const Tango::DevVarStringArray *argin)
 {
 	Tango::DevVarStringArray *argout;
-	DEBUG_STREAM << "DataBase::DbGetPropertyList()  - " << device_name << endl;
+	DEBUG_STREAM << "DataBase::DbGetPropertyList()  - " << device_name << std::endl;
 	/*----- PROTECTED REGION ID(DataBase::db_get_property_list) ENABLED START -----*/
 
 	//	Add your own code
@@ -5366,7 +5366,7 @@ Tango::DevVarStringArray *DataBase::db_get_property_list(const Tango::DevVarStri
 Tango::DevVarStringArray *DataBase::db_get_server_info(Tango::DevString argin)
 {
 	Tango::DevVarStringArray *argout;
-	DEBUG_STREAM << "DataBase::DbGetServerInfo()  - " << device_name << endl;
+	DEBUG_STREAM << "DataBase::DbGetServerInfo()  - " << device_name << std::endl;
 	/*----- PROTECTED REGION ID(DataBase::db_get_server_info) ENABLED START -----*/
 
 	//	Add your own code
@@ -5425,7 +5425,7 @@ Tango::DevVarStringArray *DataBase::db_get_server_info(Tango::DevString argin)
 Tango::DevVarStringArray *DataBase::db_get_server_list(Tango::DevString argin)
 {
 	Tango::DevVarStringArray *argout;
-	DEBUG_STREAM << "DataBase::DbGetServerList()  - " << device_name << endl;
+	DEBUG_STREAM << "DataBase::DbGetServerList()  - " << device_name << std::endl;
 	/*----- PROTECTED REGION ID(DataBase::db_get_server_list) ENABLED START -----*/
 
 	//	Add your own code
@@ -5496,7 +5496,7 @@ Tango::DevVarStringArray *DataBase::db_get_server_list(Tango::DevString argin)
 Tango::DevVarStringArray *DataBase::db_get_server_name_list(Tango::DevString argin)
 {
 	Tango::DevVarStringArray *argout;
-	DEBUG_STREAM << "DataBase::DbGetServerNameList()  - " << device_name << endl;
+	DEBUG_STREAM << "DataBase::DbGetServerNameList()  - " << device_name << std::endl;
 	/*----- PROTECTED REGION ID(DataBase::db_get_server_name_list) ENABLED START -----*/
 
 	//	Add your own code
@@ -5555,7 +5555,7 @@ Tango::DevVarStringArray *DataBase::db_get_server_name_list(Tango::DevString arg
  *           Str[3] = device server process name
  *           Str[4] = host name
  *           Str[5] = Tango class name
- *
+ *           
  *           Lg[0] = Exported flag
  *           Lg[1] = Device server process PID
  */
@@ -5563,7 +5563,7 @@ Tango::DevVarStringArray *DataBase::db_get_server_name_list(Tango::DevString arg
 Tango::DevVarLongStringArray *DataBase::db_import_device(Tango::DevString argin)
 {
 	Tango::DevVarLongStringArray *argout;
-	DEBUG_STREAM << "DataBase::DbImportDevice()  - " << device_name << endl;
+	DEBUG_STREAM << "DataBase::DbImportDevice()  - " << device_name << std::endl;
 	/*----- PROTECTED REGION ID(DataBase::db_import_device) ENABLED START -----*/
 
 	//	Add your own code
@@ -5703,7 +5703,7 @@ Tango::DevVarLongStringArray *DataBase::db_import_device(Tango::DevString argin)
 Tango::DevVarLongStringArray *DataBase::db_import_event(Tango::DevString argin)
 {
 	Tango::DevVarLongStringArray *argout;
-	DEBUG_STREAM << "DataBase::DbImportEvent()  - " << device_name << endl;
+	DEBUG_STREAM << "DataBase::DbImportEvent()  - " << device_name << std::endl;
 	/*----- PROTECTED REGION ID(DataBase::db_import_event) ENABLED START -----*/
 
 	//	Add your own code
@@ -5799,7 +5799,7 @@ Tango::DevVarLongStringArray *DataBase::db_import_event(Tango::DevString argin)
 Tango::DevVarStringArray *DataBase::db_info()
 {
 	Tango::DevVarStringArray *argout;
-	DEBUG_STREAM << "DataBase::DbInfo()  - " << device_name << endl;
+	DEBUG_STREAM << "DataBase::DbInfo()  - " << device_name << std::endl;
 	/*----- PROTECTED REGION ID(DataBase::db_info) ENABLED START -----*/
 
 	//	Add your own code
@@ -6069,7 +6069,7 @@ Tango::DevVarStringArray *DataBase::db_info()
 //--------------------------------------------------------
 void DataBase::db_put_attribute_alias(const Tango::DevVarStringArray *argin)
 {
-	DEBUG_STREAM << "DataBase::DbPutAttributeAlias()  - " << device_name << endl;
+	DEBUG_STREAM << "DataBase::DbPutAttributeAlias()  - " << device_name << std::endl;
 	/*----- PROTECTED REGION ID(DataBase::db_put_attribute_alias) ENABLED START -----*/
 
 	//	Add your own code
@@ -6182,7 +6182,7 @@ void DataBase::db_put_attribute_alias(const Tango::DevVarStringArray *argin)
 //--------------------------------------------------------
 void DataBase::db_put_class_attribute_property(const Tango::DevVarStringArray *argin)
 {
-	DEBUG_STREAM << "DataBase::DbPutClassAttributeProperty()  - " << device_name << endl;
+	DEBUG_STREAM << "DataBase::DbPutClassAttributeProperty()  - " << device_name << std::endl;
 	/*----- PROTECTED REGION ID(DataBase::db_put_class_attribute_property) ENABLED START -----*/
 
 	//	Add your own code
@@ -6268,7 +6268,7 @@ void DataBase::db_put_class_attribute_property(const Tango::DevVarStringArray *a
 //--------------------------------------------------------
 void DataBase::db_put_class_attribute_property2(const Tango::DevVarStringArray *argin)
 {
-	DEBUG_STREAM << "DataBase::DbPutClassAttributeProperty2()  - " << device_name << endl;
+	DEBUG_STREAM << "DataBase::DbPutClassAttributeProperty2()  - " << device_name << std::endl;
 	/*----- PROTECTED REGION ID(DataBase::db_put_class_attribute_property2) ENABLED START -----*/
 
 	//	Add your own code
@@ -6362,7 +6362,7 @@ void DataBase::db_put_class_attribute_property2(const Tango::DevVarStringArray *
 //--------------------------------------------------------
 void DataBase::db_put_class_property(const Tango::DevVarStringArray *argin)
 {
-	DEBUG_STREAM << "DataBase::DbPutClassProperty()  - " << device_name << endl;
+	DEBUG_STREAM << "DataBase::DbPutClassProperty()  - " << device_name << std::endl;
 	/*----- PROTECTED REGION ID(DataBase::db_put_class_property) ENABLED START -----*/
 
 	//	Add your own code
@@ -6447,7 +6447,7 @@ void DataBase::db_put_class_property(const Tango::DevVarStringArray *argin)
 //--------------------------------------------------------
 void DataBase::db_put_device_alias(const Tango::DevVarStringArray *argin)
 {
-	DEBUG_STREAM << "DataBase::DbPutDeviceAlias()  - " << device_name << endl;
+	DEBUG_STREAM << "DataBase::DbPutDeviceAlias()  - " << device_name << std::endl;
 	/*----- PROTECTED REGION ID(DataBase::db_put_device_alias) ENABLED START -----*/
 
 	//	Add your own code
@@ -6531,7 +6531,7 @@ void DataBase::db_put_device_alias(const Tango::DevVarStringArray *argin)
 //--------------------------------------------------------
 void DataBase::db_put_device_attribute_property(const Tango::DevVarStringArray *argin)
 {
-	DEBUG_STREAM << "DataBase::DbPutDeviceAttributeProperty()  - " << device_name << endl;
+	DEBUG_STREAM << "DataBase::DbPutDeviceAttributeProperty()  - " << device_name << std::endl;
 	/*----- PROTECTED REGION ID(DataBase::db_put_device_attribute_property) ENABLED START -----*/
 
 	//	Add your own code
@@ -6624,7 +6624,7 @@ void DataBase::db_put_device_attribute_property(const Tango::DevVarStringArray *
 //--------------------------------------------------------
 void DataBase::db_put_device_attribute_property2(const Tango::DevVarStringArray *argin)
 {
-	DEBUG_STREAM << "DataBase::DbPutDeviceAttributeProperty2()  - " << device_name << endl;
+	DEBUG_STREAM << "DataBase::DbPutDeviceAttributeProperty2()  - " << device_name << std::endl;
 	/*----- PROTECTED REGION ID(DataBase::db_put_device_attribute_property2) ENABLED START -----*/
 
 	//	Add your own code
@@ -6731,7 +6731,7 @@ void DataBase::db_put_device_attribute_property2(const Tango::DevVarStringArray 
 //--------------------------------------------------------
 void DataBase::db_put_device_property(const Tango::DevVarStringArray *argin)
 {
-	DEBUG_STREAM << "DataBase::DbPutDeviceProperty()  - " << device_name << endl;
+	DEBUG_STREAM << "DataBase::DbPutDeviceProperty()  - " << device_name << std::endl;
 	/*----- PROTECTED REGION ID(DataBase::db_put_device_property) ENABLED START -----*/
 
 	//	Add your own code
@@ -6828,7 +6828,7 @@ void DataBase::db_put_device_property(const Tango::DevVarStringArray *argin)
 //--------------------------------------------------------
 void DataBase::db_put_property(const Tango::DevVarStringArray *argin)
 {
-	DEBUG_STREAM << "DataBase::DbPutProperty()  - " << device_name << endl;
+	DEBUG_STREAM << "DataBase::DbPutProperty()  - " << device_name << std::endl;
 	/*----- PROTECTED REGION ID(DataBase::db_put_property) ENABLED START -----*/
 
 	//	Add your own code
@@ -6906,7 +6906,7 @@ void DataBase::db_put_property(const Tango::DevVarStringArray *argin)
 //--------------------------------------------------------
 void DataBase::db_put_server_info(const Tango::DevVarStringArray *argin)
 {
-	DEBUG_STREAM << "DataBase::DbPutServerInfo()  - " << device_name << endl;
+	DEBUG_STREAM << "DataBase::DbPutServerInfo()  - " << device_name << std::endl;
 	/*----- PROTECTED REGION ID(DataBase::db_put_server_info) ENABLED START -----*/
 
 	//	Add your own code
@@ -7003,7 +7003,7 @@ void DataBase::db_put_server_info(const Tango::DevVarStringArray *argin)
 //--------------------------------------------------------
 void DataBase::db_un_export_device(Tango::DevString argin)
 {
-	DEBUG_STREAM << "DataBase::DbUnExportDevice()  - " << device_name << endl;
+	DEBUG_STREAM << "DataBase::DbUnExportDevice()  - " << device_name << std::endl;
 	/*----- PROTECTED REGION ID(DataBase::db_un_export_device) ENABLED START -----*/
 
 	//	Add your own code
@@ -7041,7 +7041,7 @@ void DataBase::db_un_export_device(Tango::DevString argin)
 //--------------------------------------------------------
 void DataBase::db_un_export_event(Tango::DevString argin)
 {
-	DEBUG_STREAM << "DataBase::DbUnExportEvent()  - " << device_name << endl;
+	DEBUG_STREAM << "DataBase::DbUnExportEvent()  - " << device_name << std::endl;
 	/*----- PROTECTED REGION ID(DataBase::db_un_export_event) ENABLED START -----*/
 
 	//	Add your own code
@@ -7076,7 +7076,7 @@ void DataBase::db_un_export_event(Tango::DevString argin)
 //--------------------------------------------------------
 void DataBase::db_un_export_server(Tango::DevString argin)
 {
-	DEBUG_STREAM << "DataBase::DbUnExportServer()  - " << device_name << endl;
+	DEBUG_STREAM << "DataBase::DbUnExportServer()  - " << device_name << std::endl;
 	/*----- PROTECTED REGION ID(DataBase::db_un_export_server) ENABLED START -----*/
 
 	//	Add your own code
@@ -7118,7 +7118,7 @@ void DataBase::db_un_export_server(Tango::DevString argin)
 //--------------------------------------------------------
 void DataBase::reset_timing_values()
 {
-	DEBUG_STREAM << "DataBase::ResetTimingValues()  - " << device_name << endl;
+	DEBUG_STREAM << "DataBase::ResetTimingValues()  - " << device_name << std::endl;
 	/*----- PROTECTED REGION ID(DataBase::reset_timing_values) ENABLED START -----*/
 
 	//	Add your own code
@@ -7153,7 +7153,7 @@ void DataBase::reset_timing_values()
 Tango::DevVarStringArray *DataBase::db_get_data_for_server_cache(const Tango::DevVarStringArray *argin)
 {
 	Tango::DevVarStringArray *argout;
-	DEBUG_STREAM << "DataBase::DbGetDataForServerCache()  - " << device_name << endl;
+	DEBUG_STREAM << "DataBase::DbGetDataForServerCache()  - " << device_name << std::endl;
 	/*----- PROTECTED REGION ID(DataBase::db_get_data_for_server_cache) ENABLED START -----*/
 
 	//	Add your own code
@@ -7345,7 +7345,7 @@ Tango::DevVarStringArray *DataBase::db_get_data_for_server_cache(const Tango::De
 //--------------------------------------------------------
 void DataBase::db_delete_all_device_attribute_property(const Tango::DevVarStringArray *argin)
 {
-	DEBUG_STREAM << "DataBase::DbDeleteAllDeviceAttributeProperty()  - " << device_name << endl;
+	DEBUG_STREAM << "DataBase::DbDeleteAllDeviceAttributeProperty()  - " << device_name << std::endl;
 	/*----- PROTECTED REGION ID(DataBase::db_delete_all_device_attribute_property) ENABLED START -----*/
 
 	//	Add your own code
@@ -7444,7 +7444,7 @@ void DataBase::db_delete_all_device_attribute_property(const Tango::DevVarString
 Tango::DevVarLongStringArray *DataBase::db_my_sql_select(Tango::DevString argin)
 {
 	Tango::DevVarLongStringArray *argout;
-	DEBUG_STREAM << "DataBase::DbMySqlSelect()  - " << device_name << endl;
+	DEBUG_STREAM << "DataBase::DbMySqlSelect()  - " << device_name << std::endl;
 	/*----- PROTECTED REGION ID(DataBase::db_my_sql_select) ENABLED START -----*/
 
 	//	Add your own code
@@ -7533,7 +7533,7 @@ Tango::DevVarLongStringArray *DataBase::db_my_sql_select(Tango::DevString argin)
 Tango::DevVarStringArray *DataBase::db_get_csdb_server_list()
 {
 	Tango::DevVarStringArray *argout;
-	DEBUG_STREAM << "DataBase::DbGetCSDbServerList()  - " << device_name << endl;
+	DEBUG_STREAM << "DataBase::DbGetCSDbServerList()  - " << device_name << std::endl;
 	/*----- PROTECTED REGION ID(DataBase::db_get_csdb_server_list) ENABLED START -----*/
 
 	//	Add your own code
@@ -7599,7 +7599,7 @@ Tango::DevVarStringArray *DataBase::db_get_csdb_server_list()
 Tango::DevString DataBase::db_get_attribute_alias2(Tango::DevString argin)
 {
 	Tango::DevString argout;
-	DEBUG_STREAM << "DataBase::DbGetAttributeAlias2()  - " << device_name << endl;
+	DEBUG_STREAM << "DataBase::DbGetAttributeAlias2()  - " << device_name << std::endl;
 	/*----- PROTECTED REGION ID(DataBase::db_get_attribute_alias2) ENABLED START -----*/
 
 	//	Add your own code
@@ -7657,7 +7657,7 @@ Tango::DevString DataBase::db_get_attribute_alias2(Tango::DevString argin)
 Tango::DevString DataBase::db_get_alias_attribute(Tango::DevString argin)
 {
 	Tango::DevString argout;
-	DEBUG_STREAM << "DataBase::DbGetAliasAttribute()  - " << device_name << endl;
+	DEBUG_STREAM << "DataBase::DbGetAliasAttribute()  - " << device_name << std::endl;
 	/*----- PROTECTED REGION ID(DataBase::db_get_alias_attribute) ENABLED START -----*/
 
 	//	Add your own code
@@ -7716,7 +7716,7 @@ Tango::DevString DataBase::db_get_alias_attribute(Tango::DevString argin)
 //--------------------------------------------------------
 void DataBase::db_rename_server(const Tango::DevVarStringArray *argin)
 {
-	DEBUG_STREAM << "DataBase::DbRenameServer()  - " << device_name << endl;
+	DEBUG_STREAM << "DataBase::DbRenameServer()  - " << device_name << std::endl;
 	/*----- PROTECTED REGION ID(DataBase::db_rename_server) ENABLED START -----*/
 
 	//	Add your own code
@@ -7893,7 +7893,7 @@ void DataBase::db_rename_server(const Tango::DevVarStringArray *argin)
 Tango::DevVarStringArray *DataBase::db_get_class_pipe_property(const Tango::DevVarStringArray *argin)
 {
 	Tango::DevVarStringArray *argout;
-	DEBUG_STREAM << "DataBase::DbGetClassPipeProperty()  - " << device_name << endl;
+	DEBUG_STREAM << "DataBase::DbGetClassPipeProperty()  - " << device_name << std::endl;
 	/*----- PROTECTED REGION ID(DataBase::db_get_class_pipe_property) ENABLED START -----*/
 
 	//	Add your own code
@@ -8031,7 +8031,7 @@ Tango::DevVarStringArray *DataBase::db_get_class_pipe_property(const Tango::DevV
 Tango::DevVarStringArray *DataBase::db_get_device_pipe_property(const Tango::DevVarStringArray *argin)
 {
 	Tango::DevVarStringArray *argout;
-	DEBUG_STREAM << "DataBase::DbGetDevicePipeProperty()  - " << device_name << endl;
+	DEBUG_STREAM << "DataBase::DbGetDevicePipeProperty()  - " << device_name << std::endl;
 	/*----- PROTECTED REGION ID(DataBase::db_get_device_pipe_property) ENABLED START -----*/
 
 	//	Add your own code
@@ -8332,7 +8332,7 @@ Tango::DevVarStringArray *DataBase::db_get_device_pipe_property(const Tango::Dev
 //--------------------------------------------------------
 void DataBase::db_delete_class_pipe(const Tango::DevVarStringArray *argin)
 {
-	DEBUG_STREAM << "DataBase::DbDeleteClassPipe()  - " << device_name << endl;
+	DEBUG_STREAM << "DataBase::DbDeleteClassPipe()  - " << device_name << std::endl;
 	/*----- PROTECTED REGION ID(DataBase::db_delete_class_pipe) ENABLED START -----*/
 
 	//	Add your own code
@@ -8373,7 +8373,7 @@ void DataBase::db_delete_class_pipe(const Tango::DevVarStringArray *argin)
 //--------------------------------------------------------
 void DataBase::db_delete_device_pipe(const Tango::DevVarStringArray *argin)
 {
-	DEBUG_STREAM << "DataBase::DbDeleteDevicePipe()  - " << device_name << endl;
+	DEBUG_STREAM << "DataBase::DbDeleteDevicePipe()  - " << device_name << std::endl;
 	/*----- PROTECTED REGION ID(DataBase::db_delete_device_pipe) ENABLED START -----*/
 
 	//	Add your own code
@@ -8431,7 +8431,7 @@ void DataBase::db_delete_device_pipe(const Tango::DevVarStringArray *argin)
 //--------------------------------------------------------
 void DataBase::db_delete_class_pipe_property(const Tango::DevVarStringArray *argin)
 {
-	DEBUG_STREAM << "DataBase::DbDeleteClassPipeProperty()  - " << device_name << endl;
+	DEBUG_STREAM << "DataBase::DbDeleteClassPipeProperty()  - " << device_name << std::endl;
 	/*----- PROTECTED REGION ID(DataBase::db_delete_class_pipe_property) ENABLED START -----*/
 
 	//	Add your own code
@@ -8520,7 +8520,7 @@ void DataBase::db_delete_class_pipe_property(const Tango::DevVarStringArray *arg
 //--------------------------------------------------------
 void DataBase::db_delete_device_pipe_property(const Tango::DevVarStringArray *argin)
 {
-	DEBUG_STREAM << "DataBase::DbDeleteDevicePipeProperty()  - " << device_name << endl;
+	DEBUG_STREAM << "DataBase::DbDeleteDevicePipeProperty()  - " << device_name << std::endl;
 	/*----- PROTECTED REGION ID(DataBase::db_delete_device_pipe_property) ENABLED START -----*/
 
 	//	Add your own code
@@ -8616,7 +8616,7 @@ void DataBase::db_delete_device_pipe_property(const Tango::DevVarStringArray *ar
 Tango::DevVarStringArray *DataBase::db_get_class_pipe_list(const Tango::DevVarStringArray *argin)
 {
 	Tango::DevVarStringArray *argout;
-	DEBUG_STREAM << "DataBase::DbGetClassPipeList()  - " << device_name << endl;
+	DEBUG_STREAM << "DataBase::DbGetClassPipeList()  - " << device_name << std::endl;
 	/*----- PROTECTED REGION ID(DataBase::db_get_class_pipe_list) ENABLED START -----*/
 
 	//	Add your own code
@@ -8687,7 +8687,7 @@ Tango::DevVarStringArray *DataBase::db_get_class_pipe_list(const Tango::DevVarSt
 Tango::DevVarStringArray *DataBase::db_get_device_pipe_list(const Tango::DevVarStringArray *argin)
 {
 	Tango::DevVarStringArray *argout;
-	DEBUG_STREAM << "DataBase::DbGetDevicePipeList()  - " << device_name << endl;
+	DEBUG_STREAM << "DataBase::DbGetDevicePipeList()  - " << device_name << std::endl;
 	/*----- PROTECTED REGION ID(DataBase::db_get_device_pipe_list) ENABLED START -----*/
 
 	//	Add your own code
@@ -8754,7 +8754,7 @@ Tango::DevVarStringArray *DataBase::db_get_device_pipe_list(const Tango::DevVarS
 //--------------------------------------------------------
 void DataBase::db_delete_all_device_pipe_property(const Tango::DevVarStringArray *argin)
 {
-	DEBUG_STREAM << "DataBase::DbDeleteAllDevicePipeProperty()  - " << device_name << endl;
+	DEBUG_STREAM << "DataBase::DbDeleteAllDevicePipeProperty()  - " << device_name << std::endl;
 	/*----- PROTECTED REGION ID(DataBase::db_delete_all_device_pipe_property) ENABLED START -----*/
 
 	//	Add your own code
@@ -8852,7 +8852,7 @@ void DataBase::db_delete_all_device_pipe_property(const Tango::DevVarStringArray
 //--------------------------------------------------------
 void DataBase::db_put_class_pipe_property(const Tango::DevVarStringArray *argin)
 {
-	DEBUG_STREAM << "DataBase::DbPutClassPipeProperty()  - " << device_name << endl;
+	DEBUG_STREAM << "DataBase::DbPutClassPipeProperty()  - " << device_name << std::endl;
 	/*----- PROTECTED REGION ID(DataBase::db_put_class_pipe_property) ENABLED START -----*/
 
 	//	Add your own code
@@ -8945,7 +8945,7 @@ void DataBase::db_put_class_pipe_property(const Tango::DevVarStringArray *argin)
 //--------------------------------------------------------
 void DataBase::db_put_device_pipe_property(const Tango::DevVarStringArray *argin)
 {
-	DEBUG_STREAM << "DataBase::DbPutDevicePipeProperty()  - " << device_name << endl;
+	DEBUG_STREAM << "DataBase::DbPutDevicePipeProperty()  - " << device_name << std::endl;
 	/*----- PROTECTED REGION ID(DataBase::db_put_device_pipe_property) ENABLED START -----*/
 
 	//	Add your own code
@@ -9044,7 +9044,7 @@ void DataBase::db_put_device_pipe_property(const Tango::DevVarStringArray *argin
 Tango::DevVarStringArray *DataBase::db_get_class_pipe_property_hist(const Tango::DevVarStringArray *argin)
 {
 	Tango::DevVarStringArray *argout;
-	DEBUG_STREAM << "DataBase::DbGetClassPipePropertyHist()  - " << device_name << endl;
+	DEBUG_STREAM << "DataBase::DbGetClassPipePropertyHist()  - " << device_name << std::endl;
 	/*----- PROTECTED REGION ID(DataBase::db_get_class_pipe_property_hist) ENABLED START -----*/
 
 	//	Add your own code
@@ -9146,7 +9146,7 @@ Tango::DevVarStringArray *DataBase::db_get_class_pipe_property_hist(const Tango:
 Tango::DevVarStringArray *DataBase::db_get_device_pipe_property_hist(const Tango::DevVarStringArray *argin)
 {
 	Tango::DevVarStringArray *argout;
-	DEBUG_STREAM << "DataBase::DbGetDevicePipePropertyHist()  - " << device_name << endl;
+	DEBUG_STREAM << "DataBase::DbGetDevicePipePropertyHist()  - " << device_name << std::endl;
 	/*----- PROTECTED REGION ID(DataBase::db_get_device_pipe_property_hist) ENABLED START -----*/
 
 	//	Add your own code
@@ -9243,7 +9243,7 @@ Tango::DevVarStringArray *DataBase::db_get_device_pipe_property_hist(const Tango
 Tango::DevVarStringArray *DataBase::db_get_forwarded_attribute_list_for_device(Tango::DevString argin)
 {
 	Tango::DevVarStringArray *argout;
-	DEBUG_STREAM << "DataBase::DbGetForwardedAttributeListForDevice()  - " << device_name << endl;
+	DEBUG_STREAM << "DataBase::DbGetForwardedAttributeListForDevice()  - " << device_name << std::endl;
 	/*----- PROTECTED REGION ID(DataBase::db_get_forwarded_attribute_list_for_device) ENABLED START -----*/
 
 	string device(argin);

--- a/DataBase.cpp
+++ b/DataBase.cpp
@@ -444,7 +444,7 @@ void DataBase::init_device()
 		{
 		  if(strcmp((*argout)[4]," ")!=0) {
 
-			stringstream ss;
+			std::stringstream ss;
 		    ss << (*argout)[4];
 		    ss >> historyDepth;
 
@@ -1135,7 +1135,7 @@ void DataBase::db_delete_class_attribute_property(const Tango::DevVarStringArray
 			result = query(sql_query_stream.str(),"db_delete_class_attribute_property()",al.get_con_nb());
  	    	row = mysql_fetch_row(result);
 			int count;
-			stringstream ss;
+			std::stringstream ss;
 			ss << row[0];
 			ss >> count;
   	    	mysql_free_result(result);
@@ -1469,7 +1469,7 @@ void DataBase::db_delete_device_attribute_property(const Tango::DevVarStringArra
 			result = query(sql_query_stream.str(),"db_delete_device_attribute_property()",al.get_con_nb());
  	    	row = mysql_fetch_row(result);
 			int count;
-			stringstream ss;
+			std::stringstream ss;
 			ss << row[0];
 			ss >> count;
   	    	mysql_free_result(result);
@@ -2600,7 +2600,7 @@ Tango::DevVarStringArray *DataBase::db_get_class_attribute_property_hist(const T
 		{
 		   row = mysql_fetch_row(ids);
 		   Tango::DevULong64 id;
-		   stringstream ss;
+		   std::stringstream ss;
 		   ss << row[0];
 		   ss >> id;
 		   sql_query_stream.str("");
@@ -2933,7 +2933,7 @@ Tango::DevVarStringArray *DataBase::db_get_class_property_hist(const Tango::DevV
 		{
 		   row = mysql_fetch_row(ids);
 		   Tango::DevULong64 id;
-		   stringstream ss;
+		   std::stringstream ss;
 		   ss << row[0];
 		   ss >> id;
 		   sql_query_stream.str("");
@@ -3418,7 +3418,7 @@ Tango::DevVarStringArray *DataBase::db_get_device_attribute_property2(const Tang
 	{
 		if ((row = mysql_fetch_row(result)) != NULL)
 		{
-			stringstream tmp_str;
+			std::stringstream tmp_str;
 			string nb_attr_str = row[0];
 		 	tmp_str << nb_attr_str;
 			unsigned int nb_attr = 0;
@@ -3724,7 +3724,7 @@ Tango::DevVarStringArray *DataBase::db_get_device_attribute_property_hist(const 
 		{
 		   row = mysql_fetch_row(ids);
 		   Tango::DevULong64 id;
-		   stringstream ss;
+		   std::stringstream ss;
 		   ss << row[0];
 		   ss >> id;
 		   sql_query_stream.str("");
@@ -4562,7 +4562,7 @@ Tango::DevVarStringArray *DataBase::db_get_device_property_hist(const Tango::Dev
 		{
 		   row = mysql_fetch_row(ids);
 		   Tango::DevULong64 id;
-		   stringstream ss;
+		   std::stringstream ss;
 		   ss << row[0];
 		   ss >> id;
 		   sql_query_stream.str("");
@@ -5241,7 +5241,7 @@ Tango::DevVarStringArray *DataBase::db_get_property_hist(const Tango::DevVarStri
 		{
 		   row = mysql_fetch_row(ids);
 		   Tango::DevULong64 id;
-		   stringstream ss;
+		   std::stringstream ss;
 		   ss << row[0];
 		   ss >> id;
 		   sql_query_stream.str("");
@@ -7769,7 +7769,7 @@ void DataBase::db_rename_server(const Tango::DevVarStringArray *argin)
 	{
 		mysql_free_result(result);
 
-		stringstream ss;
+		std::stringstream ss;
 		ss << "Device server process name " << new_name << " is already used";
 		Tango::Except::throw_exception("Db_WrongArgument",ss.str(),"DataBase::db_rename_server()");
 	}
@@ -8079,7 +8079,7 @@ Tango::DevVarStringArray *DataBase::db_get_device_pipe_property(const Tango::Dev
 	{
 		if ((row = mysql_fetch_row(result)) != NULL)
 		{
-			stringstream tmp_str;
+			std::stringstream tmp_str;
 			string nb_pipe_str = row[0];
 		 	tmp_str << nb_pipe_str;
 			unsigned int nb_pipe = 0;
@@ -8472,7 +8472,7 @@ void DataBase::db_delete_class_pipe_property(const Tango::DevVarStringArray *arg
 			result = query(sql_query_stream.str(),"db_delete_class_pipe_property()",al.get_con_nb());
  	    	row = mysql_fetch_row(result);
 			int count;
-			stringstream ss;
+			std::stringstream ss;
 			ss << row[0];
 			ss >> count;
   	    	mysql_free_result(result);
@@ -8568,7 +8568,7 @@ void DataBase::db_delete_device_pipe_property(const Tango::DevVarStringArray *ar
 			result = query(sql_query_stream.str(),"db_delete_device_pipe_property()",al.get_con_nb());
  	    	row = mysql_fetch_row(result);
 			int count;
-			stringstream ss;
+			std::stringstream ss;
 			ss << row[0];
 			ss >> count;
   	    	mysql_free_result(result);
@@ -9089,7 +9089,7 @@ Tango::DevVarStringArray *DataBase::db_get_class_pipe_property_hist(const Tango:
 		{
 		   row = mysql_fetch_row(ids);
 		   Tango::DevULong64 id;
-		   stringstream ss;
+		   std::stringstream ss;
 		   ss << row[0];
 		   ss >> id;
 		   sql_query_stream.str("");
@@ -9191,7 +9191,7 @@ Tango::DevVarStringArray *DataBase::db_get_device_pipe_property_hist(const Tango
 		{
 		   row = mysql_fetch_row(ids);
 		   Tango::DevULong64 id;
-		   stringstream ss;
+		   std::stringstream ss;
 		   ss << row[0];
 		   ss >> id;
 		   sql_query_stream.str("");
@@ -9361,7 +9361,7 @@ void DataBase::create_update_mem_att(const Tango::DevVarStringArray *argin)
 // First the update
 //
 
-    stringstream sql_query_stream;
+    std::stringstream sql_query_stream;
     string tmp_escaped_string = escape_string((*argin)[6]);
     sql_query_stream << "UPDATE property_attribute_device SET value=\"" << tmp_escaped_string
                      << "\" WHERE device=\"" << tmp_device << "\" AND attribute=\"" << tmp_attribute
@@ -9373,7 +9373,7 @@ void DataBase::create_update_mem_att(const Tango::DevVarStringArray *argin)
     string sql_query = sql_query_stream.str();
 	if (mysql_real_query(conn_pool[con_nb].db, sql_query.c_str(),sql_query.length()) != 0)
 	{
-		stringstream o;
+		std::stringstream o;
 
 		WARN_STREAM << "DataBase::db_put_device_attribute_property2() failed to query TANGO database:" << std::endl;
 		WARN_STREAM << "  query = " << sql_query << std::endl;
@@ -9405,7 +9405,7 @@ void DataBase::create_update_mem_att(const Tango::DevVarStringArray *argin)
         sql_query = sql_query_stream.str();
         if (mysql_real_query(conn_pool[con_nb].db, sql_query.c_str(),sql_query.length()) != 0)
         {
-            stringstream o;
+            std::stringstream o;
 
             WARN_STREAM << "DataBase::db_put_device_attribute_property2() failed to query TANGO database:" << std::endl;
             WARN_STREAM << "  query = " << sql_query << std::endl;

--- a/DataBase.cpp
+++ b/DataBase.cpp
@@ -1778,7 +1778,7 @@ void DataBase::db_delete_server(Tango::DevString argin)
 	{
 		omni_mutex_lock oml(starter_mutex);
 
-		vector<std::string>	hosts;
+		std::vector<std::string>	hosts;
 		if (previous_host!="")
 		{
 			hosts.push_back(previous_host);
@@ -1959,7 +1959,7 @@ void DataBase::db_export_device(const Tango::DevVarStringArray *argin)
 	if (do_fire)
 	{
 		//	Update host's starter to update controlled servers list
-		vector<std::string>	hosts;
+		std::vector<std::string>	hosts;
 		hosts.push_back(tmp_host);
 		DEBUG_STREAM << "New Host is " << tmp_host << std::endl;
 
@@ -3526,13 +3526,13 @@ Tango::DevVarStringArray *DataBase::db_get_device_attribute_property2(const Tang
 		n_rows = mysql_num_rows(result);
 		DEBUG_STREAM << "DataBase::GetDeviceAttributeProperty2(): mysql_num_rows() " << n_rows << std::endl;
 
-		map<std::string,vector<PropDef> > db_data;
+		map<std::string,std::vector<PropDef> > db_data;
 
 		std::string att,prev_att;
 		std::string p_name,prev_p_name;
 		std::string value;
 		PropDef prop;
-		vector<PropDef> att_props;
+		std::vector<PropDef> att_props;
 
 //
 // Create a map with data coming from db
@@ -3608,7 +3608,7 @@ Tango::DevVarStringArray *DataBase::db_get_device_attribute_property2(const Tang
 			std::string tmp_att_lower(tmp_attribute);
 			transform(tmp_att_lower.begin(),tmp_att_lower.end(),tmp_att_lower.begin(),::tolower);
 
-			map<std::string,vector<PropDef> >::iterator pos = db_data.find(tmp_att_lower);
+			map<std::string,std::vector<PropDef> >::iterator pos = db_data.find(tmp_att_lower);
 
 //
 // Data for this attribute in map?
@@ -5002,7 +5002,7 @@ Tango::DevVarStringArray *DataBase::db_get_instance_name_list(Tango::DevString a
 	strcat(wildcard, "/*");
 	Tango::DevVarStringArray *server_list = db_get_server_list(wildcard);
 
-	vector<std::string>	instance_names;
+	std::vector<std::string>	instance_names;
 
 	for (unsigned  int i=0 ; i<server_list->length() ; i++)
 	{
@@ -5503,7 +5503,7 @@ Tango::DevVarStringArray *DataBase::db_get_server_name_list(Tango::DevString arg
 	Tango::DevString  wildcard = argin;
 	Tango::DevVarStringArray *server_list = db_get_server_list(wildcard);
 
-	vector<std::string>	server_names;
+	std::vector<std::string>	server_names;
 	for (unsigned int i = 0 ; i<server_list->length() ; i++)
 	{
 		//	Take only server name
@@ -6983,7 +6983,7 @@ void DataBase::db_put_server_info(const Tango::DevVarStringArray *argin)
 	{
 		omni_mutex_lock oml(starter_mutex);
 
-		vector<std::string>	hosts;
+		std::vector<std::string>	hosts;
 		if (previous_host=="")
 			hosts.push_back(tmp_host);
 		else
@@ -7861,7 +7861,7 @@ void DataBase::db_rename_server(const Tango::DevVarStringArray *argin)
 	{
 		omni_mutex_lock oml(starter_mutex);
 
-		vector<std::string>	hosts;
+		std::vector<std::string>	hosts;
 		if (previous_host!="")
 		{
 			hosts.push_back(previous_host);
@@ -8187,13 +8187,13 @@ Tango::DevVarStringArray *DataBase::db_get_device_pipe_property(const Tango::Dev
 		n_rows = mysql_num_rows(result);
 		DEBUG_STREAM << "DataBase::GetDevicePipeProperty(): mysql_num_rows() " << n_rows << std::endl;
 
-		map<std::string,vector<PropDef> > db_data;
+		map<std::string,std::vector<PropDef> > db_data;
 
 		std::string pipe,prev_pipe;
 		std::string p_name,prev_p_name;
 		std::string value;
 		PropDef prop;
-		vector<PropDef> pipe_props;
+		std::vector<PropDef> pipe_props;
 
 //
 // Create a map with data coming from db
@@ -8269,7 +8269,7 @@ Tango::DevVarStringArray *DataBase::db_get_device_pipe_property(const Tango::Dev
 			std::string tmp_pipe_lower(tmp_pipe);
 			transform(tmp_pipe_lower.begin(),tmp_pipe_lower.end(),tmp_pipe_lower.begin(),::tolower);
 
-			map<std::string,vector<PropDef> >::iterator pos = db_data.find(tmp_pipe_lower);
+			map<std::string,std::vector<PropDef> >::iterator pos = db_data.find(tmp_pipe_lower);
 
 //
 // Data for this pipe in map?

--- a/DataBase.cpp
+++ b/DataBase.cpp
@@ -182,7 +182,7 @@ namespace DataBase_ns
 /*----- PROTECTED REGION ID(DataBase::namespace_starting) ENABLED START -----*/
 
 	//	static initializations
-string DataBase::db_name("sys/database/1");
+std::string DataBase::db_name("sys/database/1");
 bool nocase_compare(char c1, char c2)
 {
 	return toupper(c1) == toupper(c2);
@@ -243,7 +243,7 @@ void DataBase::delete_device()
 	if (get_state() == Tango::ON)
 	{
 		Tango::Util *tg = Tango::Util::instance();
-		string &ds_name = tg->get_ds_name();
+		std::string &ds_name = tg->get_ds_name();
 		char *tmp_ds_name = const_cast<char *>(ds_name.c_str());
 		db_un_export_server(tmp_ds_name);
 	}
@@ -297,7 +297,7 @@ void DataBase::init_device()
 // Just to keep the rcsId string (Some compilers optimize it away)
 //
 
-	string str_rcs(RcsId);
+	std::string str_rcs(RcsId);
 
 //
 //	Initialize device
@@ -328,7 +328,7 @@ void DataBase::init_device()
 //
 
 	DummyDev d;
-	string my_user,my_password,my_host,my_name;
+	std::string my_user,my_password,my_host,my_name;
 
 	if (d.get_env_var("MYSQL_USER",my_user) != -1)
 	{
@@ -376,7 +376,7 @@ void DataBase::init_device()
 		else
 		{
 			//	Get property value
-			string	value((*argout)[4]);
+			std::string	value((*argout)[4]);
 			transform(value.begin(), value.end(), value.begin(), ::tolower);
 			if (value=="false")
 				fireToStarter = false;
@@ -396,7 +396,7 @@ void DataBase::init_device()
 	//	If fire to starter is true
 	if (fireToStarter==true)
 	{
-        string starter_domain = STARTER_DEVNAME_DOMAIN;
+        std::string starter_domain = STARTER_DEVNAME_DOMAIN;
     	//	Get starter domain if not the default one
 	    Tango::DevVarStringArray	*array = new Tango::DevVarStringArray();
 	    array->length(2);
@@ -412,7 +412,7 @@ void DataBase::init_device()
                 nb = atoi((*props)[3]); // nb values
                 if (nb==1)
                 {
-                    string domain((*props)[4]);
+                    std::string domain((*props)[4]);
                     if (!domain.empty())
                         starter_domain = domain;
                 }
@@ -808,8 +808,8 @@ void DataBase::db_add_device(const Tango::DevVarStringArray *argin)
 	TangoSys_MemStream sql_query_stream;
  	char domain[256], family[256], member[256];
 	const char *tmp_server, *tmp_class, *tmp_alias = NULL;
-	string tmp_device;
-	string dserver_name;
+	std::string tmp_device;
+	std::string dserver_name;
 	MYSQL_RES *result;
 
 
@@ -893,7 +893,7 @@ void DataBase::db_add_device(const Tango::DevVarStringArray *argin)
 		if (n_rows == 0)
 		{
 			dserver_name = "dserver/";
-			dserver_name = dserver_name + string(tmp_server);
+			dserver_name = dserver_name + std::string(tmp_server);
 			device_name_to_dfm(dserver_name, domain, family, member);
         	sql_query_stream.str("");
 			sql_query_stream << "INSERT INTO device SET name=\"dserver/" << tmp_server
@@ -952,7 +952,7 @@ void DataBase::db_add_server(const Tango::DevVarStringArray *argin)
 
 		for (unsigned int i=0; i<(server_device_list->length()-1)/2; i++)
 		{
-			string tmp_device((*server_device_list)[i*2+1].in());
+			std::string tmp_device((*server_device_list)[i*2+1].in());
 			tmp_class = (*server_device_list)[i*2+2];
 			if (!check_device_name(tmp_device))
 			{
@@ -988,7 +988,7 @@ void DataBase::db_add_server(const Tango::DevVarStringArray *argin)
 
 // Finally, add the admin device
 
-        string tmp_device("dserver/");
+        std::string tmp_device("dserver/");
         tmp_device = tmp_device + tmp_server;
 
         device_name_to_dfm(tmp_device,domain,family,member);
@@ -1055,7 +1055,7 @@ void DataBase::db_delete_class_attribute(const Tango::DevVarStringArray *argin)
 	//	Add your own code
 	TangoSys_MemStream sql_query_stream;
 	const char *attribute;
-	string tmp_class;
+	std::string tmp_class;
 
 	if (argin->length() < 2) {
    		WARN_STREAM << "DataBase::db_delete_class_attribute(): insufficient number of arguments ";
@@ -1100,7 +1100,7 @@ void DataBase::db_delete_class_attribute_property(const Tango::DevVarStringArray
 	//	Add your own code
 	TangoSys_MemStream sql_query_stream;
 	const char *attribute, *property;
-	string tmp_class;
+	std::string tmp_class;
 	MYSQL_RES *result;
 	MYSQL_ROW row;
 
@@ -1192,7 +1192,7 @@ void DataBase::db_delete_class_property(const Tango::DevVarStringArray *argin)
 	TangoSys_MemStream sql_query_stream;
 	int n_properties=0;
 	const char *tmp_class;
-	string tmp_name;
+	std::string tmp_name;
 	MYSQL_RES *result;
 	MYSQL_ROW row;
 
@@ -1265,7 +1265,7 @@ void DataBase::db_delete_device(Tango::DevString argin)
 	//	Add your own code
 	Tango::DevString  device = argin;
 	TangoSys_MemStream sql_query_stream;
-	string tmp_device;
+	std::string tmp_device;
 
 	INFO_STREAM << "DataBase::db_delete_device(): delete " << device << " from database" << std::endl;
 
@@ -1283,7 +1283,7 @@ void DataBase::db_delete_device(Tango::DevString argin)
 
 // replace database wildcards (% and _)
 
-	string tmp_wildcard = replace_wildcard(tmp_device.c_str());
+	std::string tmp_wildcard = replace_wildcard(tmp_device.c_str());
 
 	{
 		AutoLock al("LOCK TABLES device WRITE, property_device WRITE, property_attribute_device WRITE, property_pipe_device WRITE, attribute_alias WRITE",this);
@@ -1367,7 +1367,7 @@ void DataBase::db_delete_device_attribute(const Tango::DevVarStringArray *argin)
 	//	Add your own code
 	TangoSys_MemStream sql_query_stream;
 	const char *attribute;
-	string tmp_device;
+	std::string tmp_device;
 
 	if (argin->length() < 2) {
    		WARN_STREAM << "DataBase::db_delete_device_attribute(): insufficient number of arguments ";
@@ -1395,7 +1395,7 @@ void DataBase::db_delete_device_attribute(const Tango::DevVarStringArray *argin)
 
 // replace database wildcards (% and _)
 
-	string tmp_wildcard = replace_wildcard(tmp_device.c_str());
+	std::string tmp_wildcard = replace_wildcard(tmp_device.c_str());
 
 // then delete device from the property_attribute_device table
 
@@ -1427,7 +1427,7 @@ void DataBase::db_delete_device_attribute_property(const Tango::DevVarStringArra
 	//	Add your own code
 	TangoSys_MemStream sql_query_stream;
 	const char *attribute, *property;
-	string tmp_device;
+	std::string tmp_device;
 	MYSQL_RES *result;
 	MYSQL_ROW row;
 
@@ -1525,7 +1525,7 @@ void DataBase::db_delete_device_property(const Tango::DevVarStringArray *argin)
 	TangoSys_MemStream	sql_query_stream;
 	int n_properties=0;
 	const char *tmp_device;
-	string tmp_name;
+	std::string tmp_name;
 	MYSQL_RES *result;
 	MYSQL_ROW row;
 
@@ -1608,7 +1608,7 @@ void DataBase::db_delete_property(const Tango::DevVarStringArray *argin)
 	TangoSys_MemStream	sql_query_stream;
 	int n_properties=0;
 	const char *tmp_object;
-	string tmp_name;
+	std::string tmp_name;
 	MYSQL_RES *result;
 	MYSQL_ROW row;
 
@@ -1693,11 +1693,11 @@ void DataBase::db_delete_server(Tango::DevString argin)
 // first check the server name that it has no wildcard '*' and
 // that it has at least one slash in it
 
-	string tmp_server = string(server);
+	std::string tmp_server = std::string(server);
 
-	if ((tmp_server.find('*') != string::npos) ||
-	    (tmp_server.find('%') != string::npos) ||
-	    (tmp_server.find('/') == string::npos))
+	if ((tmp_server.find('*') != std::string::npos) ||
+	    (tmp_server.find('%') != std::string::npos) ||
+	    (tmp_server.find('/') == std::string::npos))
 	{
          	WARN_STREAM << "DataBase::db_delete_server(): server name  " << server << "incorrect ";
          	WARN_STREAM << std::endl;
@@ -1712,12 +1712,12 @@ void DataBase::db_delete_server(Tango::DevString argin)
 //	get  host where running
 //
 
-	string	previous_host("");
+	std::string	previous_host("");
 	if (fireToStarter==true)
 	{
 		omni_mutex_lock oml(starter_mutex);
 
-		string	adm_dev("dserver/");
+		std::string	adm_dev("dserver/");
 		adm_dev += tmp_server;
 		try
 		{
@@ -1728,7 +1728,7 @@ void DataBase::db_delete_server(Tango::DevString argin)
 		}
 		catch (Tango::DevFailed &e)
 		{
-			string reason(e.errors[0].reason.in());
+			std::string reason(e.errors[0].reason.in());
 			if (reason == DB_DeviceNotDefined)
 			{
 				WARN_STREAM << "DataBase::db_delete_server(): server " << tmp_server << " not defined in DB" << std::endl;
@@ -1778,7 +1778,7 @@ void DataBase::db_delete_server(Tango::DevString argin)
 	{
 		omni_mutex_lock oml(starter_mutex);
 
-		vector<string>	hosts;
+		vector<std::string>	hosts;
 		if (previous_host!="")
 		{
 			hosts.push_back(previous_host);
@@ -1809,7 +1809,7 @@ void DataBase::db_delete_server_info(Tango::DevString argin)
 
 // replace database wildcards (% and _)
 
-//	string tmp_wildcard = replace_wildcard(server_name);
+//	std::string tmp_wildcard = replace_wildcard(server_name);
 
 // then delete the device from the device table
     sql_query_stream << "DELETE FROM server WHERE name = \"" << server_name << "\"";
@@ -1841,7 +1841,7 @@ void DataBase::db_export_device(const Tango::DevVarStringArray *argin)
 	MYSQL_RES *result;
 	MYSQL_ROW row;
 	const char *tmp_ior, *tmp_host, *tmp_pid, *tmp_version;
-	string tmp_device, tmp_server;
+	std::string tmp_device, tmp_server;
 
 	TimeVal	before, after;
 	GetTime(before);
@@ -1871,7 +1871,7 @@ void DataBase::db_export_device(const Tango::DevVarStringArray *argin)
 //	If it is a server stating -> get previous host where running
 //
 	bool	do_fire = false;
-	string	previous_host;
+	std::string	previous_host;
 	{
 		AutoLock al("LOCK TABLES device WRITE, server WRITE",this);
 
@@ -1884,9 +1884,9 @@ void DataBase::db_export_device(const Tango::DevVarStringArray *argin)
 				//	Get database server name
 				//--------------------------------------
 				Tango::Util *tg = Tango::Util::instance();
-				string	db_serv = tg->get_ds_name();
+				std::string	db_serv = tg->get_ds_name();
 				transform(db_serv.begin(), db_serv.end(), db_serv.begin(), ::tolower);
-				string	adm_dev("dserver/");
+				std::string	adm_dev("dserver/");
 				adm_dev += db_serv;
 
 				//	Check if not database or starter servers
@@ -1959,7 +1959,7 @@ void DataBase::db_export_device(const Tango::DevVarStringArray *argin)
 	if (do_fire)
 	{
 		//	Update host's starter to update controlled servers list
-		vector<string>	hosts;
+		vector<std::string>	hosts;
 		hosts.push_back(tmp_host);
 		DEBUG_STREAM << "New Host is " << tmp_host << std::endl;
 
@@ -1997,7 +1997,7 @@ void DataBase::db_export_event(const Tango::DevVarStringArray *argin)
 	const Tango::DevVarStringArray  *export_info = argin;
 	TangoSys_MemStream sql_query_stream;
 	const char *tmp_ior, *tmp_host, *tmp_pid, *tmp_version;
-	string tmp_event, tmp_server;
+	std::string tmp_event, tmp_server;
 
 	TimeVal	before, after;
 	GetTime(before);
@@ -2063,7 +2063,7 @@ Tango::DevString DataBase::db_get_alias_device(Tango::DevString argin)
 
 	//	Add your own code
 	TangoSys_MemStream sql_query_stream;
-	string tmp_argin;
+	std::string tmp_argin;
 	MYSQL_RES *result;
 	MYSQL_ROW row;
 	int n_rows;
@@ -2098,7 +2098,7 @@ Tango::DevString DataBase::db_get_alias_device(Tango::DevString argin)
 		mysql_free_result(result);
         TangoSys_OMemStream o;
 	    o << "No device found for alias \'" << argin << "\'";
-		string msg = o.str();
+		std::string msg = o.str();
 		WARN_STREAM << msg << std::endl;
 		Tango::Except::throw_exception((const char *)DB_DeviceNotDefined,
 	   				                   msg,
@@ -2186,7 +2186,7 @@ Tango::DevVarStringArray *DataBase::db_get_attribute_alias_list(Tango::DevString
 
 	//	Add your own code
 	TangoSys_MemStream sql_query_stream;
-	string tmp_wildcard;
+	std::string tmp_wildcard;
 	MYSQL_RES *result;
 	MYSQL_ROW row;
 	int n_rows;
@@ -2257,7 +2257,7 @@ Tango::DevVarStringArray *DataBase::db_get_class_attribute_list(const Tango::Dev
 	int n_rows=0;
 	argout = new Tango::DevVarStringArray;
 	const char *class_name, *wildcard;
-	string tmp_wildcard;
+	std::string tmp_wildcard;
 
 	class_name = (*class_wildcard)[0];
 	INFO_STREAM << "DataBase::db_get_class_attribute(): get attributes for class " << class_name << std::endl;
@@ -2472,7 +2472,7 @@ Tango::DevVarStringArray *DataBase::db_get_class_attribute_property2(const Tango
 		int prop_number = 0;
 	   	if (n_rows > 0)
 	   	{
-			string name, old_name;
+			std::string name, old_name;
 			bool new_prop = true;
 			int prop_size_idx = 0;
 			int prop_size = 0;
@@ -2564,8 +2564,8 @@ Tango::DevVarStringArray *DataBase::db_get_class_attribute_property_hist(const T
 	MYSQL_RES *result;
 	MYSQL_ROW row;
 	const char *tmp_class;
-	string      tmp_attribute;
-	string      tmp_name;
+	std::string      tmp_attribute;
+	std::string      tmp_name;
 
 	if (argin->length() != 3)
 	{
@@ -2710,7 +2710,7 @@ Tango::DevVarStringArray *DataBase::db_get_class_inheritance_for_device(Tango::D
 
 	//	Add your own code
 	//	Get class for the specified device
-	string	classname = db_get_class_for_device(argin);
+	std::string	classname = db_get_class_for_device(argin);
 
 	//	Get its inheritance
 	Tango::DevVarStringArray	*array = new Tango::DevVarStringArray();
@@ -2753,7 +2753,7 @@ Tango::DevVarStringArray *DataBase::db_get_class_list(Tango::DevString argin)
 	MYSQL_RES *result;
 	MYSQL_ROW row;
 	int n_rows;
-	string tmp_server;
+	std::string tmp_server;
 
 	INFO_STREAM << "DataBase::db_get_class_list(): server " << server << std::endl;
 
@@ -2900,7 +2900,7 @@ Tango::DevVarStringArray *DataBase::db_get_class_property_hist(const Tango::DevV
 	MYSQL_RES *result;
 	MYSQL_ROW row;
 	const char *tmp_class;
-	string      tmp_name;
+	std::string      tmp_name;
 
 	if (argin->length() != 2)
 	{
@@ -3055,8 +3055,8 @@ Tango::DevString DataBase::db_get_device_alias(Tango::DevString argin)
 
 	//	Add your own code
 	TangoSys_MemStream sql_query_stream;
-	string		devname(argin);
-	string		tmp_devname;
+	std::string		devname(argin);
+	std::string		tmp_devname;
 	MYSQL_RES	*result;
 	MYSQL_ROW	row;
 	int			n_rows;
@@ -3092,7 +3092,7 @@ Tango::DevString DataBase::db_get_device_alias(Tango::DevString argin)
 				mysql_free_result(result);
   	            TangoSys_OMemStream o;
 				o << "No alias found for device \'" << devname << "\'";
-				string msg = o.str();
+				std::string msg = o.str();
 				WARN_STREAM << msg << std::endl;
 				Tango::Except::throw_exception((const char *)DB_AliasNotDefined,
 	   						                   msg,
@@ -3107,7 +3107,7 @@ Tango::DevString DataBase::db_get_device_alias(Tango::DevString argin)
 		mysql_free_result(result);
         TangoSys_OMemStream o;
 		o << "No alias found for device \'" << devname << "\'";
-		string msg = o.str();
+		std::string msg = o.str();
 		WARN_STREAM << msg << std::endl;
 		Tango::Except::throw_exception((const char *)DB_AliasNotDefined,
 	   				                   msg,
@@ -3136,7 +3136,7 @@ Tango::DevVarStringArray *DataBase::db_get_device_alias_list(Tango::DevString ar
 	//	Add your own code
 	Tango::DevString  wildcard = argin;
 	TangoSys_MemStream sql_query_stream;
-	string tmp_wildcard;
+	std::string tmp_wildcard;
 	MYSQL_RES *result;
 	MYSQL_ROW row;
 	int n_rows;
@@ -3201,7 +3201,7 @@ Tango::DevVarStringArray *DataBase::db_get_device_attribute_list(const Tango::De
 	//	Add your own code
 	const Tango::DevVarStringArray  *device_wildcard = argin;
 	TangoSys_MemStream sql_query_stream;
-	string tmp_wildcard;
+	std::string tmp_wildcard;
 	MYSQL_RES *result;
 	MYSQL_ROW row;
 	int n_rows;
@@ -3419,7 +3419,7 @@ Tango::DevVarStringArray *DataBase::db_get_device_attribute_property2(const Tang
 		if ((row = mysql_fetch_row(result)) != NULL)
 		{
 			std::stringstream tmp_str;
-			string nb_attr_str = row[0];
+			std::string nb_attr_str = row[0];
 		 	tmp_str << nb_attr_str;
 			unsigned int nb_attr = 0;
 			tmp_str >> nb_attr;
@@ -3456,7 +3456,7 @@ Tango::DevVarStringArray *DataBase::db_get_device_attribute_property2(const Tang
 			int prop_number = 0;
 	   		if (n_rows > 0)
 	   		{
-				string name, old_name;
+				std::string name, old_name;
 				bool new_prop = true;
 				int prop_size_idx = 0;
 				int prop_size = 0;
@@ -3526,11 +3526,11 @@ Tango::DevVarStringArray *DataBase::db_get_device_attribute_property2(const Tang
 		n_rows = mysql_num_rows(result);
 		DEBUG_STREAM << "DataBase::GetDeviceAttributeProperty2(): mysql_num_rows() " << n_rows << std::endl;
 
-		map<string,vector<PropDef> > db_data;
+		map<std::string,vector<PropDef> > db_data;
 
-		string att,prev_att;
-		string p_name,prev_p_name;
-		string value;
+		std::string att,prev_att;
+		std::string p_name,prev_p_name;
+		std::string value;
 		PropDef prop;
 		vector<PropDef> att_props;
 
@@ -3604,11 +3604,11 @@ Tango::DevVarStringArray *DataBase::db_get_device_attribute_property2(const Tang
 
 		for (unsigned int i=1; i<property_names->length(); i++)
 		{
-	   		string tmp_attribute((*property_names)[i]);
-			string tmp_att_lower(tmp_attribute);
+	   		std::string tmp_attribute((*property_names)[i]);
+			std::string tmp_att_lower(tmp_attribute);
 			transform(tmp_att_lower.begin(),tmp_att_lower.end(),tmp_att_lower.begin(),::tolower);
 
-			map<string,vector<PropDef> >::iterator pos = db_data.find(tmp_att_lower);
+			map<std::string,vector<PropDef> >::iterator pos = db_data.find(tmp_att_lower);
 
 //
 // Data for this attribute in map?
@@ -3688,8 +3688,8 @@ Tango::DevVarStringArray *DataBase::db_get_device_attribute_property_hist(const 
 	MYSQL_RES *result;
 	MYSQL_ROW row;
 	const char *tmp_device;
-	string      tmp_attribute;
-	string      tmp_name;
+	std::string      tmp_attribute;
+	std::string      tmp_name;
 
 	if (argin->length() != 3)
 	{
@@ -3845,7 +3845,7 @@ Tango::DevVarStringArray *DataBase::db_get_device_domain_list(Tango::DevString a
 	//	Add your own code
 	Tango::DevString  wildcard = argin;
 	TangoSys_MemStream	sql_query_stream;
-	string tmp_wildcard;
+	std::string tmp_wildcard;
 	MYSQL_RES *result;
 	MYSQL_ROW row;
 	int n_rows;
@@ -3914,7 +3914,7 @@ Tango::DevVarStringArray *DataBase::db_get_device_exported_list(Tango::DevString
 	//	Add your own code
 	Tango::DevString  filter = argin;
 	TangoSys_MemStream sql_query_stream;
-	string tmp_filter;
+	std::string tmp_filter;
 	MYSQL_RES *result;
 	MYSQL_ROW row;
 	int n_rows;
@@ -3985,7 +3985,7 @@ Tango::DevVarStringArray *DataBase::db_get_device_family_list(Tango::DevString a
 	//	Add your own code
 	Tango::DevString  wildcard = argin;
 	TangoSys_MemStream	sql_query_stream;
-	string tmp_wildcard;
+	std::string tmp_wildcard;
 	MYSQL_RES *result;
 	MYSQL_ROW row;
 	int n_rows;
@@ -4068,7 +4068,7 @@ Tango::DevVarLongStringArray *DataBase::db_get_device_info(Tango::DevString argi
 	MYSQL_ROW row;
 	int n_rows=0;
 	int exported, pid;
-	string tmp_device;
+	std::string tmp_device;
 
 	INFO_STREAM << "DataBase::ImportDevice(): get import info for " << argin << " device " << std::endl;
 
@@ -4205,8 +4205,8 @@ Tango::DevVarStringArray *DataBase::db_get_device_list(const Tango::DevVarString
 	MYSQL_RES *result;
 	MYSQL_ROW row;
 	int n_rows;
-	string tmp_server;
-	string tmp_class;
+	std::string tmp_server;
+	std::string tmp_class;
 
 	if (server_class->length() != 2)
 	{
@@ -4269,7 +4269,7 @@ Tango::DevVarStringArray *DataBase::db_get_device_wide_list(Tango::DevString arg
 	//	Add your own code
 	Tango::DevString  filter = argin;
 	TangoSys_MemStream sql_query_stream;
-	string tmp_filter;
+	std::string tmp_filter;
 	MYSQL_RES *result;
 	MYSQL_ROW row;
 	int n_rows;
@@ -4338,7 +4338,7 @@ Tango::DevVarStringArray *DataBase::db_get_device_member_list(Tango::DevString a
 	//	Add your own code
 	Tango::DevString  wildcard = argin;
 	TangoSys_MemStream	sql_query_stream;
-	string tmp_wildcard;
+	std::string tmp_wildcard;
 	MYSQL_RES *result;
 	MYSQL_ROW row;
 	int n_rows;
@@ -4425,8 +4425,8 @@ Tango::DevVarStringArray *DataBase::db_get_device_property(const Tango::DevVarSt
 	MYSQL_ROW row;
 	int n_rows=0, n_props=0;
 	const char *tmp_device;
-	string	tmp_name;
-	string	prop_name;
+	std::string	tmp_name;
+	std::string	prop_name;
 
 	TimeVal	before, after;
 	GetTime(before);
@@ -4529,7 +4529,7 @@ Tango::DevVarStringArray *DataBase::db_get_device_property_hist(const Tango::Dev
 	MYSQL_RES *result;
 	MYSQL_ROW row;
 	const char *tmp_device;
-	string      tmp_name;
+	std::string      tmp_name;
 
 	if (argin->length() != 2)
 	{
@@ -4623,7 +4623,7 @@ Tango::DevVarStringArray *DataBase::db_get_device_property_list(const Tango::Dev
 	MYSQL_ROW row;
 	int n_rows;
 	const char *device,*wildcard;
-	string tmp_wildcard;
+	std::string tmp_wildcard;
 
 	TimeVal	before, after;
 	GetTime(before);
@@ -4697,7 +4697,7 @@ Tango::DevVarStringArray *DataBase::db_get_device_server_class_list(Tango::DevSt
 	MYSQL_RES *result;
 	MYSQL_ROW row;
 	int n_rows;
-	string tmp_server;
+	std::string tmp_server;
 
 	INFO_STREAM << "DataBase::db_get_device_server_class_list(): server " << server << std::endl;
 
@@ -4750,7 +4750,7 @@ Tango::DevVarStringArray *DataBase::db_get_exportd_device_list_for_class(Tango::
 	//	Add your own code
 	Tango::DevString  classname = argin;
 	TangoSys_MemStream sql_query_stream;
-	string tmp_classname;
+	std::string tmp_classname;
 	MYSQL_RES *result;
 	MYSQL_ROW row;
 	int n_rows;
@@ -4813,7 +4813,7 @@ Tango::DevVarStringArray *DataBase::db_get_host_list(Tango::DevString argin)
 	//	Add your own code
 	Tango::DevString  wildcard = argin;
 	TangoSys_MemStream	sql_query_stream;
-	string tmp_wildcard;
+	std::string tmp_wildcard;
 	MYSQL_RES *result;
 	MYSQL_ROW row;
 	int n_rows;
@@ -4884,7 +4884,7 @@ Tango::DevVarStringArray *DataBase::db_get_host_server_list(Tango::DevString arg
 	//	Add your own code
 	Tango::DevString  wildcard = argin;
 	TangoSys_MemStream	sql_query_stream;
-	string tmp_wildcard;
+	std::string tmp_wildcard;
 	MYSQL_RES *result;
 	MYSQL_ROW row;
 	int n_rows;
@@ -5002,14 +5002,14 @@ Tango::DevVarStringArray *DataBase::db_get_instance_name_list(Tango::DevString a
 	strcat(wildcard, "/*");
 	Tango::DevVarStringArray *server_list = db_get_server_list(wildcard);
 
-	vector<string>	instance_names;
+	vector<std::string>	instance_names;
 
 	for (unsigned  int i=0 ; i<server_list->length() ; i++)
 	{
 		//	Take only server name
-		string	str((*server_list)[i]);
-		string::size_type	idx;
-		if ((idx=str.find("/"))!= string::npos)
+		std::string	str((*server_list)[i]);
+		std::string::size_type	idx;
+		if ((idx=str.find("/"))!= std::string::npos)
 		{
 			str = str.substr(idx+1);
 			instance_names.push_back(str);
@@ -5021,7 +5021,7 @@ Tango::DevVarStringArray *DataBase::db_get_instance_name_list(Tango::DevString a
 	argout->length(instance_names.size());
 	for (unsigned int i = 0 ; i<instance_names.size() ; i++)
 	{
-		string	name(instance_names[i]);
+		std::string	name(instance_names[i]);
 		(*argout)[i] = CORBA::string_dup(name.c_str());
 	}
 	delete [] wildcard;
@@ -5051,7 +5051,7 @@ Tango::DevVarStringArray *DataBase::db_get_object_list(Tango::DevString argin)
 	MYSQL_RES *result;
 	MYSQL_ROW row;
 	int n_rows;
-	string tmp_wildcard;
+	std::string tmp_wildcard;
 
 	INFO_STREAM << "DataBase::db_get_object_list(): object " << wildcard << std::endl;
 
@@ -5123,7 +5123,7 @@ Tango::DevVarStringArray *DataBase::db_get_property(const Tango::DevVarStringArr
 	int n_rows=0, n_props=0;
 	argout = new Tango::DevVarStringArray;
 	const char *tmp_object;
-	string tmp_name;
+	std::string tmp_name;
 
 	INFO_STREAM << "DataBase::db_get_property(): get " << property_names->length()-1 << " properties for object " << (*property_names)[0] << std::endl;
 
@@ -5208,7 +5208,7 @@ Tango::DevVarStringArray *DataBase::db_get_property_hist(const Tango::DevVarStri
 	MYSQL_RES *result;
 	MYSQL_ROW row;
 	const char *tmp_object;
-	string      tmp_name;
+	std::string      tmp_name;
 
 	if (argin->length() != 2)
 	{
@@ -5302,7 +5302,7 @@ Tango::DevVarStringArray *DataBase::db_get_property_list(const Tango::DevVarStri
 	MYSQL_ROW row;
 	int n_rows;
 	const char *object, *wildcard;
-	string tmp_wildcard;
+	std::string tmp_wildcard;
 
 	if (object_wildcard->length() != 2)
 	{
@@ -5376,7 +5376,7 @@ Tango::DevVarStringArray *DataBase::db_get_server_info(Tango::DevString argin)
 	MYSQL_ROW row;
 	int n_rows=0;
 	argout = new Tango::DevVarStringArray;
-	string tmp_name;
+	std::string tmp_name;
 
 	INFO_STREAM << "DataBase::db_get_server_info(): server " << server_name << std::endl;
 
@@ -5431,7 +5431,7 @@ Tango::DevVarStringArray *DataBase::db_get_server_list(Tango::DevString argin)
 	//	Add your own code
 	Tango::DevString  wildcard = argin;
 	TangoSys_MemStream	sql_query_stream;
-	string tmp_wildcard;
+	std::string tmp_wildcard;
 	MYSQL_RES *result;
 	MYSQL_ROW row;
 	int n_rows;
@@ -5503,20 +5503,20 @@ Tango::DevVarStringArray *DataBase::db_get_server_name_list(Tango::DevString arg
 	Tango::DevString  wildcard = argin;
 	Tango::DevVarStringArray *server_list = db_get_server_list(wildcard);
 
-	vector<string>	server_names;
+	vector<std::string>	server_names;
 	for (unsigned int i = 0 ; i<server_list->length() ; i++)
 	{
 		//	Take only server name
-		string	str((*server_list)[i]);
-		string::size_type	idx;
-		if ((idx=str.find("/"))!= string::npos)
+		std::string	str((*server_list)[i]);
+		std::string::size_type	idx;
+		if ((idx=str.find("/"))!= std::string::npos)
 		{
 			str = str.substr(0, idx);
 			//	Search if already in vector
 			bool	found = false;
 			for(unsigned int j=0 ; j<server_names.size() && !found ; j++)
 			{
-				string	name(server_names[j]);
+				std::string	name(server_names[j]);
 				//	compare without case sensitive
 				found = (name.size() ==  str.size()  &&   //	ensure same size
 						equal (name.begin(), name.end(),  //	server name from vector
@@ -5534,7 +5534,7 @@ Tango::DevVarStringArray *DataBase::db_get_server_name_list(Tango::DevString arg
 	argout->length(server_names.size());
 	for (unsigned int i = 0 ; i<server_names.size() ; i++)
 	{
-		string	name(server_names[i]);
+		std::string	name(server_names[i]);
 		(*argout)[i] = CORBA::string_dup(name.c_str());
 	}
 
@@ -5580,7 +5580,7 @@ Tango::DevVarLongStringArray *DataBase::db_import_device(Tango::DevString argin)
 	MYSQL_ROW row;
 	int n_rows=0;
 	int exported, pid;
-	string tmp_device;
+	std::string tmp_device;
 
 	TimeVal	before, after;
 	GetTime(before);
@@ -5713,7 +5713,7 @@ Tango::DevVarLongStringArray *DataBase::db_import_event(Tango::DevString argin)
 	MYSQL_ROW row;
 	int n_rows=0;
 	int exported, pid;
-	string tmp_event;
+	std::string tmp_event;
 
 	TimeVal	before, after;
 	GetTime(before);
@@ -6075,8 +6075,8 @@ void DataBase::db_put_attribute_alias(const Tango::DevVarStringArray *argin)
 	//	Add your own code
 	TangoSys_MemStream sql_query_stream;
 	MYSQL_RES *result;
-	string tmp_alias;
-	string tmp_name, tmp_attribute, tmp_device;
+	std::string tmp_alias;
+	std::string tmp_name, tmp_attribute, tmp_device;
 
 
 	if (argin->length() < 2) {
@@ -6126,16 +6126,16 @@ void DataBase::db_put_attribute_alias(const Tango::DevVarStringArray *argin)
 					                	  (const char *)"DataBase::db_put_attribute_alias()");
 		}
 
-		string::size_type pos=0;
+		std::string::size_type pos=0;
 		int nsep=0;
 		do
 		{
 			if (pos != 0) pos++;
 			pos = tmp_name.find("/",pos);
-			if (pos != string::npos) nsep++;
+			if (pos != std::string::npos) nsep++;
 			WARN_STREAM << "DataBase::db_put_attribute_alias(): found " << nsep << " separators , remaining string " << tmp_name.substr(pos+1) << std::endl;
 		}
-		while (pos != string::npos);
+		while (pos != std::string::npos);
 		if (nsep != 3)
 		{
 		   WARN_STREAM << "DataBase::db_put_attribute_alias(): attribute name has bad syntax, must have 3 / in it" << std::endl;
@@ -6207,7 +6207,7 @@ void DataBase::db_put_class_attribute_property(const Tango::DevVarStringArray *a
 		   for (j=k+2; j<k+n_properties*2+2; j=j+2)
 		   {
 	    	  tmp_name = (*property_list)[j];
-        	  string tmp_escaped_string = escape_string((*property_list)[j+1]);
+        	  std::string tmp_escaped_string = escape_string((*property_list)[j+1]);
 
 // first delete the tuple (device,name,count) from the property table
 			  sql_query_stream.str("");
@@ -6309,7 +6309,7 @@ void DataBase::db_put_class_attribute_property2(const Tango::DevVarStringArray *
 				Tango::DevULong64 class_attribute_property_hist_id = get_id("class_attribute",al.get_con_nb());
 	   			for (l=j+1; l<j+n_rows+1; l++)
 	   			{
-          				string tmp_escaped_string = escape_string((*argin)[l+1]);
+          				std::string tmp_escaped_string = escape_string((*argin)[l+1]);
 	      				tmp_count++; sprintf(tmp_count_str, "%d", tmp_count);
 
 // then insert the new value for this tuple
@@ -6402,7 +6402,7 @@ void DataBase::db_put_class_property(const Tango::DevVarStringArray *argin)
 		   	Tango::DevULong64 class_property_hist_id = get_id("class",al.get_con_nb());
 		   	for (j=k+2; j<k+n_rows+2; j++)
 		   	{
-        	  	string tmp_escaped_string = escape_string((*property_list)[j]);
+        	  	std::string tmp_escaped_string = escape_string((*property_list)[j]);
 	    	  	tmp_count++; sprintf(tmp_count_str, "%d", tmp_count);
 
 // then insert the new value for this tuple
@@ -6454,8 +6454,8 @@ void DataBase::db_put_device_alias(const Tango::DevVarStringArray *argin)
 	const Tango::DevVarStringArray  *device_alias = argin;
 	TangoSys_MemStream sql_query_stream;
 	MYSQL_RES *result;
-	string tmp_alias;
-	string tmp_device;
+	std::string tmp_alias;
+	std::string tmp_device;
 
 
 	if (device_alias->length() < 2) {
@@ -6560,7 +6560,7 @@ void DataBase::db_put_device_attribute_property(const Tango::DevVarStringArray *
 		   for (j=k+2; j<k+n_properties*2+2; j=j+2)
 		   {
 	    	  tmp_name = (*property_list)[j];
-        	  string tmp_escaped_string = escape_string((*property_list)[j+1]);
+        	  std::string tmp_escaped_string = escape_string((*property_list)[j+1]);
 
 // first delete the tuple (device,name,count) from the property table
 				sql_query_stream.str("");
@@ -6678,7 +6678,7 @@ void DataBase::db_put_device_attribute_property2(const Tango::DevVarStringArray 
 
                     for (l=j+1; l<j+n_rows+1; l++)
                     {
-                        string tmp_escaped_string = escape_string((*argin)[l+1]);
+                        std::string tmp_escaped_string = escape_string((*argin)[l+1]);
                         tmp_count++; sprintf(tmp_count_str, "%d", tmp_count);
 
 // then insert the new value for this tuple
@@ -6740,7 +6740,7 @@ void DataBase::db_put_device_property(const Tango::DevVarStringArray *argin)
 	char tmp_count_str[256];
 	int n_properties=0, n_rows=0;
 	const char *tmp_device;
-	string tmp_name;
+	std::string tmp_name;
 
 	TimeVal	before, after;
 	GetTime(before);
@@ -6773,7 +6773,7 @@ void DataBase::db_put_device_property(const Tango::DevVarStringArray *argin)
 
 		   for (j=k+2; j<k+n_rows+2; j++)
 		   {
-        	  string tmp_escaped_string = escape_string((*property_list)[j]);
+        	  std::string tmp_escaped_string = escape_string((*property_list)[j]);
 	    	  tmp_count++; sprintf(tmp_count_str, "%d", tmp_count);
 
 			// then insert the new value for this tuple
@@ -6836,7 +6836,7 @@ void DataBase::db_put_property(const Tango::DevVarStringArray *argin)
 	TangoSys_MemStream	sql_query_stream;
 	int n_properties=0, n_rows=0;
 	const char *tmp_object;
-	string tmp_name;
+	std::string tmp_name;
 
 	tmp_object = (*property_list)[0];
 	sscanf((*property_list)[1],"%6d", &n_properties);
@@ -6864,7 +6864,7 @@ void DataBase::db_put_property(const Tango::DevVarStringArray *argin)
 			Tango::DevULong64 object_property_hist_id = get_id("object",al.get_con_nb());
 	    	for (int j=k+2 ; j<k+n_rows+2 ; j++)
 	    	{
-        	  string tmp_escaped_string = escape_string((*property_list)[j]);
+        	  std::string tmp_escaped_string = escape_string((*property_list)[j]);
 	    	  tmp_count++;
 
 			  // then insert the new value for this tuple
@@ -6913,7 +6913,7 @@ void DataBase::db_put_server_info(const Tango::DevVarStringArray *argin)
 	const Tango::DevVarStringArray  *server_info = argin;
 	TangoSys_MemStream sql_query_stream;
 	const char *tmp_host, *tmp_mode, *tmp_level;
-	string tmp_server;
+	std::string tmp_server;
 
 	if (server_info->length() < 4) {
    		WARN_STREAM << "DataBase::db_put_server_info(): insufficient info for server ";
@@ -6939,7 +6939,7 @@ void DataBase::db_put_server_info(const Tango::DevVarStringArray *argin)
 //	If it is an empty host name -> get previous host where running
 //
 
-	string previous_host("");
+	std::string previous_host("");
 	{
 		AutoLock al("LOCK TABLES device READ, server WRITE",this);
 
@@ -6952,9 +6952,9 @@ void DataBase::db_put_server_info(const Tango::DevVarStringArray *argin)
 				//	Get database server name
 				//--------------------------------------
 				Tango::Util *tg = Tango::Util::instance();
-				string	db_serv = tg->get_ds_name();
+				std::string	db_serv = tg->get_ds_name();
 				transform(db_serv.begin(), db_serv.end(), db_serv.begin(), ::tolower);
-				string	adm_dev = "dserver/";
+				std::string	adm_dev = "dserver/";
 				adm_dev += tmp_server;
 
 				char *tmp_ptr = db_get_device_host((Tango::DevString)adm_dev.c_str(),al.get_con_nb());
@@ -6983,7 +6983,7 @@ void DataBase::db_put_server_info(const Tango::DevVarStringArray *argin)
 	{
 		omni_mutex_lock oml(starter_mutex);
 
-		vector<string>	hosts;
+		vector<std::string>	hosts;
 		if (previous_host=="")
 			hosts.push_back(tmp_host);
 		else
@@ -7047,7 +7047,7 @@ void DataBase::db_un_export_event(Tango::DevString argin)
 	//	Add your own code
 	Tango::DevString  event_name = argin;
 	TangoSys_MemStream sql_query_stream;
-	string tmp_event;
+	std::string tmp_event;
 
 	INFO_STREAM << "DataBase::un_export_event(): un-export " << event_name << " device " << std::endl;
 
@@ -7187,15 +7187,15 @@ Tango::DevVarStringArray *DataBase::db_get_data_for_server_cache(const Tango::De
 	TimeVal	before, after;
 	GetTime(before);
 
-	string	sql_query;
-	string svc((*argin)[0]);
-	string host((*argin)[1]);
+	std::string	sql_query;
+	std::string svc((*argin)[0]);
+	std::string host((*argin)[1]);
 	MYSQL_RES *res;
 	MYSQL_ROW row;
 
 	Tango::Util *tg = Tango::Util::instance();
-	string	&db_inst_name = tg->get_ds_inst_name();
-	string tmp_var_name("@param_out");
+	std::string	&db_inst_name = tg->get_ds_inst_name();
+	std::string tmp_var_name("@param_out");
 	tmp_var_name = tmp_var_name + db_inst_name;
 
 //
@@ -7277,7 +7277,7 @@ Tango::DevVarStringArray *DataBase::db_get_data_for_server_cache(const Tango::De
 
 	row = mysql_fetch_row(res);
 	unsigned long *length_ptr = mysql_fetch_lengths(res);
-	string str(row[0],length_ptr[0]);
+	std::string str(row[0],length_ptr[0]);
 #ifdef __SUNPRO_CC
 	int nb_field;
 	count(str.begin(),str.end(),'\0',nb_field);
@@ -7309,13 +7309,13 @@ Tango::DevVarStringArray *DataBase::db_get_data_for_server_cache(const Tango::De
 
 	argout->length(nb_field + 1);
 
-	string::size_type pos = 0;
-	string::size_type start = 0;
+	std::string::size_type pos = 0;
+	std::string::size_type start = 0;
 	int idx = 0;
-	string tmp_elt;
+	std::string tmp_elt;
 
 	pos = str.find('\0');
-	while (pos != string::npos)
+	while (pos != std::string::npos)
 	{
 		tmp_elt = str.substr(start,pos - start);
 		(*argout)[idx] = CORBA::string_dup(tmp_elt.c_str());
@@ -7351,7 +7351,7 @@ void DataBase::db_delete_all_device_attribute_property(const Tango::DevVarString
 	//	Add your own code
 	TangoSys_MemStream sql_query_stream;
 	const char *attribute;
-	string tmp_device;
+	std::string tmp_device;
 	MYSQL_RES *result;
 	MYSQL_ROW row;
 
@@ -7452,21 +7452,21 @@ Tango::DevVarLongStringArray *DataBase::db_my_sql_select(Tango::DevString argin)
 	GetTime(before);
 
 	//	Check if SELECT key is alread inside command
-	string	cmd(argin);
-	string	tmp(argin);
+	std::string	cmd(argin);
+	std::string	tmp(argin);
 	transform(tmp.begin(), tmp.end(), tmp.begin(), ::tolower);
-	string::size_type	idx = tmp.find("select");
-	if (idx == string::npos)
+	std::string::size_type	idx = tmp.find("select");
+	if (idx == std::string::npos)
 		cmd = "SELECT " + cmd;
 
 	// Check that there is no SQL injection
 
 	idx = tmp.find(';');
-	if ((idx != string::npos) && (tmp.size() > (idx + 1)))
+	if ((idx != std::string::npos) && (tmp.size() > (idx + 1)))
 	{
  	    TangoSys_OMemStream o;
 		o << "SQL command not valid: \'" << argin << "\'";
-		string msg = o.str();
+		std::string msg = o.str();
 		WARN_STREAM << msg << std::endl;
 		Tango::Except::throw_exception((const char *)DB_IncorrectArguments,
 	   				                   msg,
@@ -7560,7 +7560,7 @@ Tango::DevVarStringArray *DataBase::db_get_csdb_server_list()
 	      if ((row = mysql_fetch_row(result)) != NULL)
 	      {
 	         DEBUG_STREAM << "DataBase::db_get_csdb_server_list(): ior[ "<< i << "] " << row[0] << std::endl;
-			 string h_p;
+			 std::string h_p;
 			 bool ret = host_port_from_ior(row[0],h_p);
 			 if (ret == true)
 	         	(*argout)[i] = CORBA::string_dup(h_p.c_str());
@@ -7570,7 +7570,7 @@ Tango::DevVarStringArray *DataBase::db_get_csdb_server_list()
 				delete argout;
  	    		TangoSys_OMemStream o;
 				o << "Wrong IOR in database for at least one of the database server(s)";
-				string msg = o.str();
+				std::string msg = o.str();
 				WARN_STREAM << msg << std::endl;
 				Tango::Except::throw_exception((const char *)"DB_WrongIORForDbServer",
 	   				                   msg,
@@ -7732,15 +7732,15 @@ void DataBase::db_rename_server(const Tango::DevVarStringArray *argin)
 					                   "DataBase::db_rename_server()");
 	}
 
-	string old_name((*argin)[0]);
-	string new_name((*argin)[1]);
+	std::string old_name((*argin)[0]);
+	std::string new_name((*argin)[1]);
 
-	string::size_type pos_old,pos_new;
+	std::string::size_type pos_old,pos_new;
 
 	pos_old = old_name.find('/');
 	pos_new = new_name.find('/');
 
-	if ((pos_old == string::npos) || (pos_new == string::npos))
+	if ((pos_old == std::string::npos) || (pos_new == std::string::npos))
 	{
 		Tango::Except::throw_exception("Db_WrongArgument","Wrong syntax in command args (ds_exec_name/inst_name)",
 										"DataBase::db_rename_server()");
@@ -7750,7 +7750,7 @@ void DataBase::db_rename_server(const Tango::DevVarStringArray *argin)
 // Check that the new name is not already used
 //
 
-	string new_adm_name("dserver/");
+	std::string new_adm_name("dserver/");
 	new_adm_name = new_adm_name + new_name;
 
 	TangoSys_MemStream sql_query_stream;
@@ -7777,12 +7777,12 @@ void DataBase::db_rename_server(const Tango::DevVarStringArray *argin)
 //
 //	get  host where running
 //
-	string	previous_host("");
+	std::string	previous_host("");
 	if (fireToStarter==true)
 	{
 		omni_mutex_lock oml(starter_mutex);
 
-		string	adm_dev("dserver/");
+		std::string	adm_dev("dserver/");
 		adm_dev += old_name;
 		try
 		{
@@ -7793,7 +7793,7 @@ void DataBase::db_rename_server(const Tango::DevVarStringArray *argin)
 		}
 		catch (Tango::DevFailed &e)
 		{
-			string reason(e.errors[0].reason.in());
+			std::string reason(e.errors[0].reason.in());
 			if (reason == DB_DeviceNotDefined)
 			{
 				WARN_STREAM << "DataBase::db_delete_server(): server " << old_name << " not defined in DB" << std::endl;
@@ -7815,11 +7815,11 @@ void DataBase::db_rename_server(const Tango::DevVarStringArray *argin)
 // 4 - Change admin device attribute property (if any)
 //
 
-	string old_adm_name("dserver/");
+	std::string old_adm_name("dserver/");
 	old_adm_name = old_adm_name + old_name;
 
-	string new_exec = new_name.substr(0,pos_new);
-	string new_inst = new_name.substr(pos_new + 1);
+	std::string new_exec = new_name.substr(0,pos_new);
+	std::string new_inst = new_name.substr(pos_new + 1);
 
 	{
 		AutoLock al("LOCK TABLES device WRITE, property_device WRITE, property_attribute_device WRITE",this);
@@ -7861,7 +7861,7 @@ void DataBase::db_rename_server(const Tango::DevVarStringArray *argin)
 	{
 		omni_mutex_lock oml(starter_mutex);
 
-		vector<string>	hosts;
+		vector<std::string>	hosts;
 		if (previous_host!="")
 		{
 			hosts.push_back(previous_host);
@@ -7944,7 +7944,7 @@ Tango::DevVarStringArray *DataBase::db_get_class_pipe_property(const Tango::DevV
 		int prop_number = 0;
 	   	if (n_rows > 0)
 	   	{
-			string name, old_name;
+			std::string name, old_name;
 			bool new_prop = true;
 			int prop_size_idx = 0;
 			int prop_size = 0;
@@ -8080,7 +8080,7 @@ Tango::DevVarStringArray *DataBase::db_get_device_pipe_property(const Tango::Dev
 		if ((row = mysql_fetch_row(result)) != NULL)
 		{
 			std::stringstream tmp_str;
-			string nb_pipe_str = row[0];
+			std::string nb_pipe_str = row[0];
 		 	tmp_str << nb_pipe_str;
 			unsigned int nb_pipe = 0;
 			tmp_str >> nb_pipe;
@@ -8117,7 +8117,7 @@ Tango::DevVarStringArray *DataBase::db_get_device_pipe_property(const Tango::Dev
 			int prop_number = 0;
 	   		if (n_rows > 0)
 	   		{
-				string name, old_name;
+				std::string name, old_name;
 				bool new_prop = true;
 				int prop_size_idx = 0;
 				int prop_size = 0;
@@ -8187,11 +8187,11 @@ Tango::DevVarStringArray *DataBase::db_get_device_pipe_property(const Tango::Dev
 		n_rows = mysql_num_rows(result);
 		DEBUG_STREAM << "DataBase::GetDevicePipeProperty(): mysql_num_rows() " << n_rows << std::endl;
 
-		map<string,vector<PropDef> > db_data;
+		map<std::string,vector<PropDef> > db_data;
 
-		string pipe,prev_pipe;
-		string p_name,prev_p_name;
-		string value;
+		std::string pipe,prev_pipe;
+		std::string p_name,prev_p_name;
+		std::string value;
 		PropDef prop;
 		vector<PropDef> pipe_props;
 
@@ -8265,11 +8265,11 @@ Tango::DevVarStringArray *DataBase::db_get_device_pipe_property(const Tango::Dev
 
 		for (unsigned int i=1; i<property_names->length(); i++)
 		{
-	   		string tmp_pipe((*property_names)[i]);
-			string tmp_pipe_lower(tmp_pipe);
+	   		std::string tmp_pipe((*property_names)[i]);
+			std::string tmp_pipe_lower(tmp_pipe);
 			transform(tmp_pipe_lower.begin(),tmp_pipe_lower.end(),tmp_pipe_lower.begin(),::tolower);
 
-			map<string,vector<PropDef> >::iterator pos = db_data.find(tmp_pipe_lower);
+			map<std::string,vector<PropDef> >::iterator pos = db_data.find(tmp_pipe_lower);
 
 //
 // Data for this pipe in map?
@@ -8338,7 +8338,7 @@ void DataBase::db_delete_class_pipe(const Tango::DevVarStringArray *argin)
 	//	Add your own code
 	TangoSys_MemStream sql_query_stream;
 	const char *pipe;
-	string tmp_class;
+	std::string tmp_class;
 
 	if (argin->length() < 2) {
    		WARN_STREAM << "DataBase::db_delete_class_pipe(): insufficient number of arguments ";
@@ -8379,7 +8379,7 @@ void DataBase::db_delete_device_pipe(const Tango::DevVarStringArray *argin)
 	//	Add your own code
 	TangoSys_MemStream sql_query_stream;
 	const char *pipe;
-	string tmp_device;
+	std::string tmp_device;
 
 	if (argin->length() < 2) {
    		WARN_STREAM << "DataBase::db_delete_device_pipe(): insufficient number of arguments ";
@@ -8407,7 +8407,7 @@ void DataBase::db_delete_device_pipe(const Tango::DevVarStringArray *argin)
 
 // replace database wildcards (% and _)
 
-	string tmp_wildcard = replace_wildcard(tmp_device.c_str());
+	std::string tmp_wildcard = replace_wildcard(tmp_device.c_str());
 
 // then delete device from the property_attribute_device table
 
@@ -8437,7 +8437,7 @@ void DataBase::db_delete_class_pipe_property(const Tango::DevVarStringArray *arg
 	//	Add your own code
 	TangoSys_MemStream sql_query_stream;
 	const char *pipe, *property;
-	string tmp_class;
+	std::string tmp_class;
 	MYSQL_RES *result;
 	MYSQL_ROW row;
 
@@ -8526,7 +8526,7 @@ void DataBase::db_delete_device_pipe_property(const Tango::DevVarStringArray *ar
 	//	Add your own code
 	TangoSys_MemStream sql_query_stream;
 	const char *pipe, *property;
-	string tmp_device;
+	std::string tmp_device;
 	MYSQL_RES *result;
 	MYSQL_ROW row;
 
@@ -8627,7 +8627,7 @@ Tango::DevVarStringArray *DataBase::db_get_class_pipe_list(const Tango::DevVarSt
 	int n_rows=0;
 	argout = new Tango::DevVarStringArray;
 	const char *class_name, *wildcard;
-	string tmp_wildcard;
+	std::string tmp_wildcard;
 
 	class_name = (*class_wildcard)[0];
 	INFO_STREAM << "DataBase::db_get_class_pipe_list(): get pipes for class " << class_name << std::endl;
@@ -8693,7 +8693,7 @@ Tango::DevVarStringArray *DataBase::db_get_device_pipe_list(const Tango::DevVarS
 	//	Add your own code
 	const Tango::DevVarStringArray  *device_wildcard = argin;
 	TangoSys_MemStream sql_query_stream;
-	string tmp_wildcard;
+	std::string tmp_wildcard;
 	MYSQL_RES *result;
 	MYSQL_ROW row;
 	int n_rows;
@@ -8760,7 +8760,7 @@ void DataBase::db_delete_all_device_pipe_property(const Tango::DevVarStringArray
 	//	Add your own code
 	TangoSys_MemStream sql_query_stream;
 	const char *pipe;
-	string tmp_device;
+	std::string tmp_device;
 	MYSQL_RES *result;
 	MYSQL_ROW row;
 
@@ -8893,7 +8893,7 @@ void DataBase::db_put_class_pipe_property(const Tango::DevVarStringArray *argin)
 				Tango::DevULong64 class_pipe_property_hist_id = get_id("class_pipe",al.get_con_nb());
 	   			for (l=j+1; l<j+n_rows+1; l++)
 	   			{
-          				string tmp_escaped_string = escape_string((*argin)[l+1]);
+          				std::string tmp_escaped_string = escape_string((*argin)[l+1]);
 	      				tmp_count++; sprintf(tmp_count_str, "%d", tmp_count);
 
 // then insert the new value for this tuple
@@ -8990,7 +8990,7 @@ void DataBase::db_put_device_pipe_property(const Tango::DevVarStringArray *argin
 
 	   			for (l=j+1; l<j+n_rows+1; l++)
 	   			{
-          			string tmp_escaped_string = escape_string((*argin)[l+1]);
+          			std::string tmp_escaped_string = escape_string((*argin)[l+1]);
 	      			tmp_count++; sprintf(tmp_count_str, "%d", tmp_count);
 
 // then insert the new value for this tuple
@@ -9053,8 +9053,8 @@ Tango::DevVarStringArray *DataBase::db_get_class_pipe_property_hist(const Tango:
 	MYSQL_RES *result;
 	MYSQL_ROW row;
 	const char *tmp_class;
-	string      tmp_pipe;
-	string      tmp_name;
+	std::string      tmp_pipe;
+	std::string      tmp_name;
 
 	if (argin->length() != 3)
 	{
@@ -9155,8 +9155,8 @@ Tango::DevVarStringArray *DataBase::db_get_device_pipe_property_hist(const Tango
 	MYSQL_RES *result;
 	MYSQL_ROW row;
 	const char *tmp_device;
-	string      tmp_pipe;
-	string      tmp_name;
+	std::string      tmp_pipe;
+	std::string      tmp_name;
 
 	if (argin->length() != 3)
 	{
@@ -9246,7 +9246,7 @@ Tango::DevVarStringArray *DataBase::db_get_forwarded_attribute_list_for_device(T
 	DEBUG_STREAM << "DataBase::DbGetForwardedAttributeListForDevice()  - " << device_name << std::endl;
 	/*----- PROTECTED REGION ID(DataBase::db_get_forwarded_attribute_list_for_device) ENABLED START -----*/
 
-	string device(argin);
+	std::string device(argin);
 
 	TangoSys_MemStream	sql_query_stream;
     sql_query_stream << "SELECT device,attribute,value  FROM property_attribute_device WHERE name = \"__root_att"
@@ -9303,7 +9303,7 @@ void DataBase::add_dynamic_commands()
 Tango::DevString DataBase::db_get_device_host(Tango::DevString argin,int con_nb)
 {
 	TangoSys_MemStream sql_query_stream;
-	string tmp_argin;
+	std::string tmp_argin;
 	MYSQL_RES *result;
 	MYSQL_ROW row;
 	int n_rows;
@@ -9328,7 +9328,7 @@ Tango::DevString DataBase::db_get_device_host(Tango::DevString argin,int con_nb)
 		mysql_free_result(result);
  	    TangoSys_OMemStream o;
 		o << "No host found for device \'" << argin << "\'";
-		string msg = o.str();
+		std::string msg = o.str();
 		WARN_STREAM << msg << std::endl;
 		Tango::Except::throw_exception((const char *)DB_DeviceNotDefined,
 	   				                   msg,
@@ -9362,7 +9362,7 @@ void DataBase::create_update_mem_att(const Tango::DevVarStringArray *argin)
 //
 
     std::stringstream sql_query_stream;
-    string tmp_escaped_string = escape_string((*argin)[6]);
+    std::string tmp_escaped_string = escape_string((*argin)[6]);
     sql_query_stream << "UPDATE property_attribute_device SET value=\"" << tmp_escaped_string
                      << "\" WHERE device=\"" << tmp_device << "\" AND attribute=\"" << tmp_attribute
                      << "\" AND name=\"__value\" AND count=1";
@@ -9370,7 +9370,7 @@ void DataBase::create_update_mem_att(const Tango::DevVarStringArray *argin)
 
     int con_nb = get_connection();
 
-    string sql_query = sql_query_stream.str();
+    std::string sql_query = sql_query_stream.str();
 	if (mysql_real_query(conn_pool[con_nb].db, sql_query.c_str(),sql_query.length()) != 0)
 	{
 		std::stringstream o;

--- a/DataBase.h
+++ b/DataBase.h
@@ -210,7 +210,7 @@ public:
 	 *	@param cl	Class.
 	 *	@param s 	Device Name
 	 */
-	DataBase(Tango::DeviceClass *cl,string &s);
+	DataBase(Tango::DeviceClass *cl,std::string &s);
 	/**
 	 * Constructs a newly device object.
 	 *
@@ -256,11 +256,11 @@ public:
 	 *	Description : Hardware acquisition for attributes.
 	 */
 	//--------------------------------------------------------
-	virtual void read_attr_hardware(vector<long> &attr_list);
+	virtual void read_attr_hardware(std::vector<long> &attr_list);
 
 /**
  *	Attribute StoredProcedureRelease related methods
- *	Description:
+ *	Description: 
  *
  *	Data type:	Tango::DevString
  *	Attr type:	Scalar
@@ -269,7 +269,7 @@ public:
 	virtual bool is_StoredProcedureRelease_allowed(Tango::AttReqType type);
 /**
  *	Attribute Timing_average related methods
- *	Description:
+ *	Description: 
  *
  *	Data type:	Tango::DevDouble
  *	Attr type:	Spectrum max = 64
@@ -278,7 +278,7 @@ public:
 	virtual bool is_Timing_average_allowed(Tango::AttReqType type);
 /**
  *	Attribute Timing_minimum related methods
- *	Description:
+ *	Description: 
  *
  *	Data type:	Tango::DevDouble
  *	Attr type:	Spectrum max = 64
@@ -287,7 +287,7 @@ public:
 	virtual bool is_Timing_minimum_allowed(Tango::AttReqType type);
 /**
  *	Attribute Timing_maximum related methods
- *	Description:
+ *	Description: 
  *
  *	Data type:	Tango::DevDouble
  *	Attr type:	Spectrum max = 64
@@ -296,7 +296,7 @@ public:
 	virtual bool is_Timing_maximum_allowed(Tango::AttReqType type);
 /**
  *	Attribute Timing_calls related methods
- *	Description:
+ *	Description: 
  *
  *	Data type:	Tango::DevDouble
  *	Attr type:	Spectrum max = 64
@@ -305,7 +305,7 @@ public:
 	virtual bool is_Timing_calls_allowed(Tango::AttReqType type);
 /**
  *	Attribute Timing_index related methods
- *	Description:
+ *	Description: 
  *
  *	Data type:	Tango::DevString
  *	Attr type:	Spectrum max = 64
@@ -314,7 +314,7 @@ public:
 	virtual bool is_Timing_index_allowed(Tango::AttReqType type);
 /**
  *	Attribute Timing_info related methods
- *	Description:
+ *	Description: 
  *
  *	Data type:	Tango::DevString
  *	Attr type:	Spectrum max = 64
@@ -624,7 +624,7 @@ public:
 	virtual bool is_DbGetClassList_allowed(const CORBA::Any &any);
 	/**
 	 *	Command DbGetClassProperty related method
-	 *	Description:
+	 *	Description: 
 	 *
 	 *	@param argin Str[0] = Tango class
 	 *               Str[1] = Property name
@@ -799,7 +799,7 @@ public:
 	 *           Str[5] = Started date (or ? if not set)
 	 *           Str[6] = Stopped date (or ? if not set)
 	 *           Str[7] = Device class
-	 *
+	 *           
 	 *           Lg[0] = Device exported flag
 	 *           Lg[1] = Device Server process PID (or -1 if not set)
 	 */
@@ -836,7 +836,7 @@ public:
 	virtual bool is_DbGetDeviceMemberList_allowed(const CORBA::Any &any);
 	/**
 	 *	Command DbGetDeviceProperty related method
-	 *	Description:
+	 *	Description: 
 	 *
 	 *	@param argin Str[0] = Device name
 	 *               Str[1] = Property name
@@ -1029,7 +1029,7 @@ public:
 	 *           Str[3] = device server process name
 	 *           Str[4] = host name
 	 *           Str[5] = Tango class name
-	 *
+	 *           
 	 *           Lg[0] = Exported flag
 	 *           Lg[1] = Device server process PID
 	 */

--- a/DataBase.h
+++ b/DataBase.h
@@ -183,7 +183,7 @@ public:
 	{
 		std::string			prop_name;
 		std::string 			prop_name_cd;
-		vector<std::string>	prop_val;
+		std::vector<std::string>	prop_val;
 	} PropDef;
 
 private:

--- a/DataBase.h
+++ b/DataBase.h
@@ -166,7 +166,7 @@ public:
 		double maximum;
 	} TimingStatsStruct;
 
-	map<std::string,TimingStatsStruct*> timing_stats_map;
+	std::map<std::string,TimingStatsStruct*> timing_stats_map;
 
 	int timing_stats_size;
 	double *timing_stats_average;

--- a/DataBase.h
+++ b/DataBase.h
@@ -111,14 +111,14 @@ class DummyDev: public Tango::Connection
 public:
 	DummyDev():Tango::Connection(true) {};
 
-	virtual string get_corba_name(bool) {string str;return str;}
-	virtual string build_corba_name() {string str;return str;}
+	virtual std::string get_corba_name(bool) {std::string str;return str;}
+	virtual std::string build_corba_name() {std::string str;return str;}
 	virtual int get_lock_ctr() {return 0;}
 	virtual void set_lock_ctr(int) {};
 
-	virtual string dev_name() {string str;return str;}
+	virtual std::string dev_name() {std::string str;return str;}
 
-	int get_env_var(const char *cc,string &str_ref) {return Tango::Connection::get_env_var(cc,str_ref);}
+	int get_env_var(const char *cc,std::string &str_ref) {return Tango::Connection::get_env_var(cc,str_ref);}
 };
 
 	/*----- PROTECTED REGION END -----*/	//	DataBase::Additional Class Declarations
@@ -133,7 +133,7 @@ public:
 	/**
 	 *	current incarnation of database
 	 */
-	static string db_name;
+	static std::string db_name;
 
 	/**
 	 *	Will be set by property of Default object
@@ -181,13 +181,13 @@ public:
 
 	typedef struct prop_def
 	{
-		string			prop_name;
-		string 			prop_name_cd;
-		vector<string>	prop_val;
+		std::string			prop_name;
+		std::string 			prop_name_cd;
+		vector<std::string>	prop_val;
 	} PropDef;
 
 private:
-    string              mysql_db_name;
+    std::string              mysql_db_name;
 
 	/*----- PROTECTED REGION END -----*/	//	DataBase::Data Members
 
@@ -1494,11 +1494,11 @@ public:
 protected :
 	unsigned long	mysql_svr_version;
 
-	bool check_device_name(string &);
-	bool device_name_to_dfm(string &device_name, char domain[], char family[], char member[]);
-	string replace_wildcard(const char*);
+	bool check_device_name(std::string &);
+	bool device_name_to_dfm(std::string &device_name, char domain[], char family[], char member[]);
+	std::string replace_wildcard(const char*);
 	Tango::DevString db_get_device_host(Tango::DevString,int con_nb=-1);
-	string escape_string(const char *string_c_str);
+	std::string escape_string(const char *string_c_str);
 	void init_timing_stats();
 	Tango::DevULong64 get_id(const char *name,int con_nb=-1);
 	void check_history_tables();
@@ -1517,7 +1517,7 @@ protected :
 	char 			*stored_release_ptr;
 	char			stored_release[128];
 
-	string			ho;
+	std::string			ho;
 	char			ho_name[1024];
 
 	omni_mutex		timing_stats_mutex;
@@ -1526,7 +1526,7 @@ protected :
 
 	void create_connection_pool(const char *,const char *,const char *,const char *);
 	void base_connect(int);
-	bool host_port_from_ior(const char *,string &);
+	bool host_port_from_ior(const char *,std::string &);
     void create_update_mem_att(const Tango::DevVarStringArray *);
 
 	inline void update_timing_stats(TimeVal before, TimeVal after, std::string command)
@@ -1562,8 +1562,8 @@ protected :
 
 public:
 
-	void simple_query(string sql_query,const char *method,int con_nb=-1);
-	MYSQL_RES *query(string sql_query,const char *method,int con_nb=-1);
+	void simple_query(std::string sql_query,const char *method,int con_nb=-1);
+	MYSQL_RES *query(std::string sql_query,const char *method,int con_nb=-1);
 	static void set_conn_pool_size(int si) {conn_pool_size = si;}
 
 	int get_connection();

--- a/DataBase.xmi
+++ b/DataBase.xmi
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="ASCII"?>
 <pogoDsl:PogoSystem xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:pogoDsl="http://www.esrf.fr/tango/pogo/PogoDsl">
-  <classes name="DataBase" pogoRevision="9.1">
-    <description description="This class manage the TANGO database." title="TANGO" sourcePath="/mntdirect/_segfs/tango/cppserver/dbase/src" language="Cpp" filestogenerate="XMI   file,Code files,Protected Regions" hasMandatoryProperty="false" hasConcreteProperty="false" hasAbstractCommand="false" hasAbstractAttribute="false">
-      <inheritances classname="Device_4Impl" sourcePath="../../../../../../segfs/tango/templates/AbstractClasses"/>
+  <classes name="DataBase" pogoRevision="9.7">
+    <description description="This class manage the TANGO database." title="TANGO" sourcePath="/Users/benjaminbertrand/Dev/Tango/TangoDatabase" language="Cpp" filestogenerate="XMI   file,Code files,Protected Regions" hasMandatoryProperty="false" hasConcreteProperty="false" hasAbstractCommand="false" hasAbstractAttribute="false">
+      <inheritances classname="Device_4Impl" sourcePath="../../../../segfs/tango/templates/AbstractClasses"/>
       <identification contact="at esrf.fr - accelerator-control" author="accelerator-control" emailDomain="esrf.fr" classFamily="System" siteSpecific="" platform="All Platforms" bus="Not Applicable" manufacturer="none" reference=""/>
     </description>
     <commands name="State" description="This command gets the device state (stored in its &lt;i>device_state&lt;/i> data member) and returns it to the caller." execMethod="dev_state" displayLevel="OPERATOR" polledPeriod="0">
@@ -945,7 +945,7 @@
       <status abstract="false" inherited="false" concrete="true" concreteHere="true"/>
       <properties description="" label="" unit="" standardUnit="" displayUnit="" format="" maxValue="" minValue="" maxAlarm="" minAlarm="" maxWarning="" minWarning="" deltaTime="" deltaValue=""/>
     </attributes>
-    <preferences docHome="./doc_html" makefileHome="/segfs/tango/cppserver/env"/>
+    <preferences docHome="./doc_html" makefileHome="$(TANGO_HOME)"/>
     <additionalFiles name="DataBaseUtils" path="/mntdirect/_segfs/tango/cppserver/dbase/DataBaseUtils.cpp"/>
     <additionalFiles name="update_starter" path="/mntdirect/_segfs/tango/cppserver/dbase/update_starter.cpp"/>
   </classes>

--- a/DataBaseClass.cpp
+++ b/DataBaseClass.cpp
@@ -94,7 +94,7 @@ DataBaseClass::DataBaseClass(std::string &s):Tango::DeviceClass(s)
 	write_class_property();
 
 	/*----- PROTECTED REGION ID(DataBaseClass::constructor) ENABLED START -----*/
-	string str_rcs(RcsId);
+	std::string str_rcs(RcsId);
 	/*----- PROTECTED REGION END -----*/	//	DataBaseClass::constructor
 
 	cout2 << "Leaving DataBaseClass constructor" << std::endl;

--- a/DataBaseClass.cpp
+++ b/DataBaseClass.cpp
@@ -81,15 +81,15 @@ DataBaseClass *DataBaseClass::_instance = NULL;
 
 //--------------------------------------------------------
 /**
- * method : 		DataBaseClass::DataBaseClass(string &s)
+ * method : 		DataBaseClass::DataBaseClass(std::string &s)
  * description : 	constructor for the DataBaseClass
  *
  * @param s	The class name
  */
 //--------------------------------------------------------
-DataBaseClass::DataBaseClass(string &s):Tango::DeviceClass(s)
+DataBaseClass::DataBaseClass(std::string &s):Tango::DeviceClass(s)
 {
-	cout2 << "Entering DataBaseClass constructor" << endl;
+	cout2 << "Entering DataBaseClass constructor" << std::endl;
 	set_default_property();
 	write_class_property();
 
@@ -97,7 +97,7 @@ DataBaseClass::DataBaseClass(string &s):Tango::DeviceClass(s)
 	string str_rcs(RcsId);
 	/*----- PROTECTED REGION END -----*/	//	DataBaseClass::constructor
 
-	cout2 << "Leaving DataBaseClass constructor" << endl;
+	cout2 << "Leaving DataBaseClass constructor" << std::endl;
 }
 
 //--------------------------------------------------------
@@ -131,10 +131,10 @@ DataBaseClass *DataBaseClass::init(const char *name)
 	{
 		try
 		{
-			string s(name);
+			std::string s(name);
 			_instance = new DataBaseClass(s);
 		}
-		catch (bad_alloc &)
+		catch (std::bad_alloc &)
 		{
 			throw;
 		}
@@ -153,7 +153,7 @@ DataBaseClass *DataBaseClass::instance()
 {
 	if (_instance == NULL)
 	{
-		cerr << "Class is not initialised !!" << endl;
+		std::cerr << "Class is not initialised !!" << std::endl;
 		exit(-1);
 	}
 	return _instance;
@@ -177,7 +177,7 @@ DataBaseClass *DataBaseClass::instance()
 //--------------------------------------------------------
 CORBA::Any *DbAddDeviceClass::execute(Tango::DeviceImpl *device, const CORBA::Any &in_any)
 {
-	cout2 << "DbAddDeviceClass::execute(): arrived" << endl;
+	cout2 << "DbAddDeviceClass::execute(): arrived" << std::endl;
 	const Tango::DevVarStringArray *argin;
 	extract(in_any, argin);
 	((static_cast<DataBase *>(device))->db_add_device(argin));
@@ -197,7 +197,7 @@ CORBA::Any *DbAddDeviceClass::execute(Tango::DeviceImpl *device, const CORBA::An
 //--------------------------------------------------------
 CORBA::Any *DbAddServerClass::execute(Tango::DeviceImpl *device, const CORBA::Any &in_any)
 {
-	cout2 << "DbAddServerClass::execute(): arrived" << endl;
+	cout2 << "DbAddServerClass::execute(): arrived" << std::endl;
 	const Tango::DevVarStringArray *argin;
 	extract(in_any, argin);
 	((static_cast<DataBase *>(device))->db_add_server(argin));
@@ -217,7 +217,7 @@ CORBA::Any *DbAddServerClass::execute(Tango::DeviceImpl *device, const CORBA::An
 //--------------------------------------------------------
 CORBA::Any *DbDeleteAttributeAliasClass::execute(Tango::DeviceImpl *device, const CORBA::Any &in_any)
 {
-	cout2 << "DbDeleteAttributeAliasClass::execute(): arrived" << endl;
+	cout2 << "DbDeleteAttributeAliasClass::execute(): arrived" << std::endl;
 	Tango::DevString argin;
 	extract(in_any, argin);
 	((static_cast<DataBase *>(device))->db_delete_attribute_alias(argin));
@@ -237,7 +237,7 @@ CORBA::Any *DbDeleteAttributeAliasClass::execute(Tango::DeviceImpl *device, cons
 //--------------------------------------------------------
 CORBA::Any *DbDeleteClassAttributeClass::execute(Tango::DeviceImpl *device, const CORBA::Any &in_any)
 {
-	cout2 << "DbDeleteClassAttributeClass::execute(): arrived" << endl;
+	cout2 << "DbDeleteClassAttributeClass::execute(): arrived" << std::endl;
 	const Tango::DevVarStringArray *argin;
 	extract(in_any, argin);
 	((static_cast<DataBase *>(device))->db_delete_class_attribute(argin));
@@ -257,7 +257,7 @@ CORBA::Any *DbDeleteClassAttributeClass::execute(Tango::DeviceImpl *device, cons
 //--------------------------------------------------------
 CORBA::Any *DbDeleteClassAttributePropertyClass::execute(Tango::DeviceImpl *device, const CORBA::Any &in_any)
 {
-	cout2 << "DbDeleteClassAttributePropertyClass::execute(): arrived" << endl;
+	cout2 << "DbDeleteClassAttributePropertyClass::execute(): arrived" << std::endl;
 	const Tango::DevVarStringArray *argin;
 	extract(in_any, argin);
 	((static_cast<DataBase *>(device))->db_delete_class_attribute_property(argin));
@@ -277,7 +277,7 @@ CORBA::Any *DbDeleteClassAttributePropertyClass::execute(Tango::DeviceImpl *devi
 //--------------------------------------------------------
 CORBA::Any *DbDeleteClassPropertyClass::execute(Tango::DeviceImpl *device, const CORBA::Any &in_any)
 {
-	cout2 << "DbDeleteClassPropertyClass::execute(): arrived" << endl;
+	cout2 << "DbDeleteClassPropertyClass::execute(): arrived" << std::endl;
 	const Tango::DevVarStringArray *argin;
 	extract(in_any, argin);
 	((static_cast<DataBase *>(device))->db_delete_class_property(argin));
@@ -297,7 +297,7 @@ CORBA::Any *DbDeleteClassPropertyClass::execute(Tango::DeviceImpl *device, const
 //--------------------------------------------------------
 CORBA::Any *DbDeleteDeviceClass::execute(Tango::DeviceImpl *device, const CORBA::Any &in_any)
 {
-	cout2 << "DbDeleteDeviceClass::execute(): arrived" << endl;
+	cout2 << "DbDeleteDeviceClass::execute(): arrived" << std::endl;
 	Tango::DevString argin;
 	extract(in_any, argin);
 	((static_cast<DataBase *>(device))->db_delete_device(argin));
@@ -317,7 +317,7 @@ CORBA::Any *DbDeleteDeviceClass::execute(Tango::DeviceImpl *device, const CORBA:
 //--------------------------------------------------------
 CORBA::Any *DbDeleteDeviceAliasClass::execute(Tango::DeviceImpl *device, const CORBA::Any &in_any)
 {
-	cout2 << "DbDeleteDeviceAliasClass::execute(): arrived" << endl;
+	cout2 << "DbDeleteDeviceAliasClass::execute(): arrived" << std::endl;
 	Tango::DevString argin;
 	extract(in_any, argin);
 	((static_cast<DataBase *>(device))->db_delete_device_alias(argin));
@@ -337,7 +337,7 @@ CORBA::Any *DbDeleteDeviceAliasClass::execute(Tango::DeviceImpl *device, const C
 //--------------------------------------------------------
 CORBA::Any *DbDeleteDeviceAttributeClass::execute(Tango::DeviceImpl *device, const CORBA::Any &in_any)
 {
-	cout2 << "DbDeleteDeviceAttributeClass::execute(): arrived" << endl;
+	cout2 << "DbDeleteDeviceAttributeClass::execute(): arrived" << std::endl;
 	const Tango::DevVarStringArray *argin;
 	extract(in_any, argin);
 	((static_cast<DataBase *>(device))->db_delete_device_attribute(argin));
@@ -357,7 +357,7 @@ CORBA::Any *DbDeleteDeviceAttributeClass::execute(Tango::DeviceImpl *device, con
 //--------------------------------------------------------
 CORBA::Any *DbDeleteDeviceAttributePropertyClass::execute(Tango::DeviceImpl *device, const CORBA::Any &in_any)
 {
-	cout2 << "DbDeleteDeviceAttributePropertyClass::execute(): arrived" << endl;
+	cout2 << "DbDeleteDeviceAttributePropertyClass::execute(): arrived" << std::endl;
 	const Tango::DevVarStringArray *argin;
 	extract(in_any, argin);
 	((static_cast<DataBase *>(device))->db_delete_device_attribute_property(argin));
@@ -377,7 +377,7 @@ CORBA::Any *DbDeleteDeviceAttributePropertyClass::execute(Tango::DeviceImpl *dev
 //--------------------------------------------------------
 CORBA::Any *DbDeleteDevicePropertyClass::execute(Tango::DeviceImpl *device, const CORBA::Any &in_any)
 {
-	cout2 << "DbDeleteDevicePropertyClass::execute(): arrived" << endl;
+	cout2 << "DbDeleteDevicePropertyClass::execute(): arrived" << std::endl;
 	const Tango::DevVarStringArray *argin;
 	extract(in_any, argin);
 	((static_cast<DataBase *>(device))->db_delete_device_property(argin));
@@ -397,7 +397,7 @@ CORBA::Any *DbDeleteDevicePropertyClass::execute(Tango::DeviceImpl *device, cons
 //--------------------------------------------------------
 CORBA::Any *DbDeletePropertyClass::execute(Tango::DeviceImpl *device, const CORBA::Any &in_any)
 {
-	cout2 << "DbDeletePropertyClass::execute(): arrived" << endl;
+	cout2 << "DbDeletePropertyClass::execute(): arrived" << std::endl;
 	const Tango::DevVarStringArray *argin;
 	extract(in_any, argin);
 	((static_cast<DataBase *>(device))->db_delete_property(argin));
@@ -417,7 +417,7 @@ CORBA::Any *DbDeletePropertyClass::execute(Tango::DeviceImpl *device, const CORB
 //--------------------------------------------------------
 CORBA::Any *DbDeleteServerClass::execute(Tango::DeviceImpl *device, const CORBA::Any &in_any)
 {
-	cout2 << "DbDeleteServerClass::execute(): arrived" << endl;
+	cout2 << "DbDeleteServerClass::execute(): arrived" << std::endl;
 	Tango::DevString argin;
 	extract(in_any, argin);
 	((static_cast<DataBase *>(device))->db_delete_server(argin));
@@ -437,7 +437,7 @@ CORBA::Any *DbDeleteServerClass::execute(Tango::DeviceImpl *device, const CORBA:
 //--------------------------------------------------------
 CORBA::Any *DbDeleteServerInfoClass::execute(Tango::DeviceImpl *device, const CORBA::Any &in_any)
 {
-	cout2 << "DbDeleteServerInfoClass::execute(): arrived" << endl;
+	cout2 << "DbDeleteServerInfoClass::execute(): arrived" << std::endl;
 	Tango::DevString argin;
 	extract(in_any, argin);
 	((static_cast<DataBase *>(device))->db_delete_server_info(argin));
@@ -457,7 +457,7 @@ CORBA::Any *DbDeleteServerInfoClass::execute(Tango::DeviceImpl *device, const CO
 //--------------------------------------------------------
 CORBA::Any *DbExportDeviceClass::execute(Tango::DeviceImpl *device, const CORBA::Any &in_any)
 {
-	cout2 << "DbExportDeviceClass::execute(): arrived" << endl;
+	cout2 << "DbExportDeviceClass::execute(): arrived" << std::endl;
 	const Tango::DevVarStringArray *argin;
 	extract(in_any, argin);
 	((static_cast<DataBase *>(device))->db_export_device(argin));
@@ -477,7 +477,7 @@ CORBA::Any *DbExportDeviceClass::execute(Tango::DeviceImpl *device, const CORBA:
 //--------------------------------------------------------
 CORBA::Any *DbExportEventClass::execute(Tango::DeviceImpl *device, const CORBA::Any &in_any)
 {
-	cout2 << "DbExportEventClass::execute(): arrived" << endl;
+	cout2 << "DbExportEventClass::execute(): arrived" << std::endl;
 	const Tango::DevVarStringArray *argin;
 	extract(in_any, argin);
 	((static_cast<DataBase *>(device))->db_export_event(argin));
@@ -497,7 +497,7 @@ CORBA::Any *DbExportEventClass::execute(Tango::DeviceImpl *device, const CORBA::
 //--------------------------------------------------------
 CORBA::Any *DbGetAliasDeviceClass::execute(Tango::DeviceImpl *device, const CORBA::Any &in_any)
 {
-	cout2 << "DbGetAliasDeviceClass::execute(): arrived" << endl;
+	cout2 << "DbGetAliasDeviceClass::execute(): arrived" << std::endl;
 	Tango::DevString argin;
 	extract(in_any, argin);
 	return insert((static_cast<DataBase *>(device))->db_get_alias_device(argin));
@@ -516,7 +516,7 @@ CORBA::Any *DbGetAliasDeviceClass::execute(Tango::DeviceImpl *device, const CORB
 //--------------------------------------------------------
 CORBA::Any *DbGetAttributeAliasClass::execute(Tango::DeviceImpl *device, const CORBA::Any &in_any)
 {
-	cout2 << "DbGetAttributeAliasClass::execute(): arrived" << endl;
+	cout2 << "DbGetAttributeAliasClass::execute(): arrived" << std::endl;
 	Tango::DevString argin;
 	extract(in_any, argin);
 	return insert((static_cast<DataBase *>(device))->db_get_attribute_alias(argin));
@@ -535,7 +535,7 @@ CORBA::Any *DbGetAttributeAliasClass::execute(Tango::DeviceImpl *device, const C
 //--------------------------------------------------------
 CORBA::Any *DbGetAttributeAliasListClass::execute(Tango::DeviceImpl *device, const CORBA::Any &in_any)
 {
-	cout2 << "DbGetAttributeAliasListClass::execute(): arrived" << endl;
+	cout2 << "DbGetAttributeAliasListClass::execute(): arrived" << std::endl;
 	Tango::DevString argin;
 	extract(in_any, argin);
 	return insert((static_cast<DataBase *>(device))->db_get_attribute_alias_list(argin));
@@ -554,7 +554,7 @@ CORBA::Any *DbGetAttributeAliasListClass::execute(Tango::DeviceImpl *device, con
 //--------------------------------------------------------
 CORBA::Any *DbGetClassAttributeListClass::execute(Tango::DeviceImpl *device, const CORBA::Any &in_any)
 {
-	cout2 << "DbGetClassAttributeListClass::execute(): arrived" << endl;
+	cout2 << "DbGetClassAttributeListClass::execute(): arrived" << std::endl;
 	const Tango::DevVarStringArray *argin;
 	extract(in_any, argin);
 	return insert((static_cast<DataBase *>(device))->db_get_class_attribute_list(argin));
@@ -573,7 +573,7 @@ CORBA::Any *DbGetClassAttributeListClass::execute(Tango::DeviceImpl *device, con
 //--------------------------------------------------------
 CORBA::Any *DbGetClassAttributePropertyClass::execute(Tango::DeviceImpl *device, const CORBA::Any &in_any)
 {
-	cout2 << "DbGetClassAttributePropertyClass::execute(): arrived" << endl;
+	cout2 << "DbGetClassAttributePropertyClass::execute(): arrived" << std::endl;
 	const Tango::DevVarStringArray *argin;
 	extract(in_any, argin);
 	return insert((static_cast<DataBase *>(device))->db_get_class_attribute_property(argin));
@@ -592,7 +592,7 @@ CORBA::Any *DbGetClassAttributePropertyClass::execute(Tango::DeviceImpl *device,
 //--------------------------------------------------------
 CORBA::Any *DbGetClassAttributeProperty2Class::execute(Tango::DeviceImpl *device, const CORBA::Any &in_any)
 {
-	cout2 << "DbGetClassAttributeProperty2Class::execute(): arrived" << endl;
+	cout2 << "DbGetClassAttributeProperty2Class::execute(): arrived" << std::endl;
 	const Tango::DevVarStringArray *argin;
 	extract(in_any, argin);
 	return insert((static_cast<DataBase *>(device))->db_get_class_attribute_property2(argin));
@@ -611,7 +611,7 @@ CORBA::Any *DbGetClassAttributeProperty2Class::execute(Tango::DeviceImpl *device
 //--------------------------------------------------------
 CORBA::Any *DbGetClassAttributePropertyHistClass::execute(Tango::DeviceImpl *device, const CORBA::Any &in_any)
 {
-	cout2 << "DbGetClassAttributePropertyHistClass::execute(): arrived" << endl;
+	cout2 << "DbGetClassAttributePropertyHistClass::execute(): arrived" << std::endl;
 	const Tango::DevVarStringArray *argin;
 	extract(in_any, argin);
 	return insert((static_cast<DataBase *>(device))->db_get_class_attribute_property_hist(argin));
@@ -630,7 +630,7 @@ CORBA::Any *DbGetClassAttributePropertyHistClass::execute(Tango::DeviceImpl *dev
 //--------------------------------------------------------
 CORBA::Any *DbGetClassForDeviceClass::execute(Tango::DeviceImpl *device, const CORBA::Any &in_any)
 {
-	cout2 << "DbGetClassForDeviceClass::execute(): arrived" << endl;
+	cout2 << "DbGetClassForDeviceClass::execute(): arrived" << std::endl;
 	Tango::DevString argin;
 	extract(in_any, argin);
 	return insert((static_cast<DataBase *>(device))->db_get_class_for_device(argin));
@@ -649,7 +649,7 @@ CORBA::Any *DbGetClassForDeviceClass::execute(Tango::DeviceImpl *device, const C
 //--------------------------------------------------------
 CORBA::Any *DbGetClassInheritanceForDeviceClass::execute(Tango::DeviceImpl *device, const CORBA::Any &in_any)
 {
-	cout2 << "DbGetClassInheritanceForDeviceClass::execute(): arrived" << endl;
+	cout2 << "DbGetClassInheritanceForDeviceClass::execute(): arrived" << std::endl;
 	Tango::DevString argin;
 	extract(in_any, argin);
 	return insert((static_cast<DataBase *>(device))->db_get_class_inheritance_for_device(argin));
@@ -668,7 +668,7 @@ CORBA::Any *DbGetClassInheritanceForDeviceClass::execute(Tango::DeviceImpl *devi
 //--------------------------------------------------------
 CORBA::Any *DbGetClassListClass::execute(Tango::DeviceImpl *device, const CORBA::Any &in_any)
 {
-	cout2 << "DbGetClassListClass::execute(): arrived" << endl;
+	cout2 << "DbGetClassListClass::execute(): arrived" << std::endl;
 	Tango::DevString argin;
 	extract(in_any, argin);
 	return insert((static_cast<DataBase *>(device))->db_get_class_list(argin));
@@ -687,7 +687,7 @@ CORBA::Any *DbGetClassListClass::execute(Tango::DeviceImpl *device, const CORBA:
 //--------------------------------------------------------
 CORBA::Any *DbGetClassPropertyClass::execute(Tango::DeviceImpl *device, const CORBA::Any &in_any)
 {
-	cout2 << "DbGetClassPropertyClass::execute(): arrived" << endl;
+	cout2 << "DbGetClassPropertyClass::execute(): arrived" << std::endl;
 	const Tango::DevVarStringArray *argin;
 	extract(in_any, argin);
 	return insert((static_cast<DataBase *>(device))->db_get_class_property(argin));
@@ -706,7 +706,7 @@ CORBA::Any *DbGetClassPropertyClass::execute(Tango::DeviceImpl *device, const CO
 //--------------------------------------------------------
 CORBA::Any *DbGetClassPropertyHistClass::execute(Tango::DeviceImpl *device, const CORBA::Any &in_any)
 {
-	cout2 << "DbGetClassPropertyHistClass::execute(): arrived" << endl;
+	cout2 << "DbGetClassPropertyHistClass::execute(): arrived" << std::endl;
 	const Tango::DevVarStringArray *argin;
 	extract(in_any, argin);
 	return insert((static_cast<DataBase *>(device))->db_get_class_property_hist(argin));
@@ -725,7 +725,7 @@ CORBA::Any *DbGetClassPropertyHistClass::execute(Tango::DeviceImpl *device, cons
 //--------------------------------------------------------
 CORBA::Any *DbGetClassPropertyListClass::execute(Tango::DeviceImpl *device, const CORBA::Any &in_any)
 {
-	cout2 << "DbGetClassPropertyListClass::execute(): arrived" << endl;
+	cout2 << "DbGetClassPropertyListClass::execute(): arrived" << std::endl;
 	Tango::DevString argin;
 	extract(in_any, argin);
 	return insert((static_cast<DataBase *>(device))->db_get_class_property_list(argin));
@@ -744,7 +744,7 @@ CORBA::Any *DbGetClassPropertyListClass::execute(Tango::DeviceImpl *device, cons
 //--------------------------------------------------------
 CORBA::Any *DbGetDeviceAliasClass::execute(Tango::DeviceImpl *device, const CORBA::Any &in_any)
 {
-	cout2 << "DbGetDeviceAliasClass::execute(): arrived" << endl;
+	cout2 << "DbGetDeviceAliasClass::execute(): arrived" << std::endl;
 	Tango::DevString argin;
 	extract(in_any, argin);
 	return insert((static_cast<DataBase *>(device))->db_get_device_alias(argin));
@@ -763,7 +763,7 @@ CORBA::Any *DbGetDeviceAliasClass::execute(Tango::DeviceImpl *device, const CORB
 //--------------------------------------------------------
 CORBA::Any *DbGetDeviceAliasListClass::execute(Tango::DeviceImpl *device, const CORBA::Any &in_any)
 {
-	cout2 << "DbGetDeviceAliasListClass::execute(): arrived" << endl;
+	cout2 << "DbGetDeviceAliasListClass::execute(): arrived" << std::endl;
 	Tango::DevString argin;
 	extract(in_any, argin);
 	return insert((static_cast<DataBase *>(device))->db_get_device_alias_list(argin));
@@ -782,7 +782,7 @@ CORBA::Any *DbGetDeviceAliasListClass::execute(Tango::DeviceImpl *device, const 
 //--------------------------------------------------------
 CORBA::Any *DbGetDeviceAttributeListClass::execute(Tango::DeviceImpl *device, const CORBA::Any &in_any)
 {
-	cout2 << "DbGetDeviceAttributeListClass::execute(): arrived" << endl;
+	cout2 << "DbGetDeviceAttributeListClass::execute(): arrived" << std::endl;
 	const Tango::DevVarStringArray *argin;
 	extract(in_any, argin);
 	return insert((static_cast<DataBase *>(device))->db_get_device_attribute_list(argin));
@@ -801,7 +801,7 @@ CORBA::Any *DbGetDeviceAttributeListClass::execute(Tango::DeviceImpl *device, co
 //--------------------------------------------------------
 CORBA::Any *DbGetDeviceAttributePropertyClass::execute(Tango::DeviceImpl *device, const CORBA::Any &in_any)
 {
-	cout2 << "DbGetDeviceAttributePropertyClass::execute(): arrived" << endl;
+	cout2 << "DbGetDeviceAttributePropertyClass::execute(): arrived" << std::endl;
 	const Tango::DevVarStringArray *argin;
 	extract(in_any, argin);
 	return insert((static_cast<DataBase *>(device))->db_get_device_attribute_property(argin));
@@ -820,7 +820,7 @@ CORBA::Any *DbGetDeviceAttributePropertyClass::execute(Tango::DeviceImpl *device
 //--------------------------------------------------------
 CORBA::Any *DbGetDeviceAttributeProperty2Class::execute(Tango::DeviceImpl *device, const CORBA::Any &in_any)
 {
-	cout2 << "DbGetDeviceAttributeProperty2Class::execute(): arrived" << endl;
+	cout2 << "DbGetDeviceAttributeProperty2Class::execute(): arrived" << std::endl;
 	const Tango::DevVarStringArray *argin;
 	extract(in_any, argin);
 	return insert((static_cast<DataBase *>(device))->db_get_device_attribute_property2(argin));
@@ -839,7 +839,7 @@ CORBA::Any *DbGetDeviceAttributeProperty2Class::execute(Tango::DeviceImpl *devic
 //--------------------------------------------------------
 CORBA::Any *DbGetDeviceAttributePropertyHistClass::execute(Tango::DeviceImpl *device, const CORBA::Any &in_any)
 {
-	cout2 << "DbGetDeviceAttributePropertyHistClass::execute(): arrived" << endl;
+	cout2 << "DbGetDeviceAttributePropertyHistClass::execute(): arrived" << std::endl;
 	const Tango::DevVarStringArray *argin;
 	extract(in_any, argin);
 	return insert((static_cast<DataBase *>(device))->db_get_device_attribute_property_hist(argin));
@@ -858,7 +858,7 @@ CORBA::Any *DbGetDeviceAttributePropertyHistClass::execute(Tango::DeviceImpl *de
 //--------------------------------------------------------
 CORBA::Any *DbGetDeviceClassListClass::execute(Tango::DeviceImpl *device, const CORBA::Any &in_any)
 {
-	cout2 << "DbGetDeviceClassListClass::execute(): arrived" << endl;
+	cout2 << "DbGetDeviceClassListClass::execute(): arrived" << std::endl;
 	Tango::DevString argin;
 	extract(in_any, argin);
 	return insert((static_cast<DataBase *>(device))->db_get_device_class_list(argin));
@@ -877,7 +877,7 @@ CORBA::Any *DbGetDeviceClassListClass::execute(Tango::DeviceImpl *device, const 
 //--------------------------------------------------------
 CORBA::Any *DbGetDeviceDomainListClass::execute(Tango::DeviceImpl *device, const CORBA::Any &in_any)
 {
-	cout2 << "DbGetDeviceDomainListClass::execute(): arrived" << endl;
+	cout2 << "DbGetDeviceDomainListClass::execute(): arrived" << std::endl;
 	Tango::DevString argin;
 	extract(in_any, argin);
 	return insert((static_cast<DataBase *>(device))->db_get_device_domain_list(argin));
@@ -896,7 +896,7 @@ CORBA::Any *DbGetDeviceDomainListClass::execute(Tango::DeviceImpl *device, const
 //--------------------------------------------------------
 CORBA::Any *DbGetDeviceExportedListClass::execute(Tango::DeviceImpl *device, const CORBA::Any &in_any)
 {
-	cout2 << "DbGetDeviceExportedListClass::execute(): arrived" << endl;
+	cout2 << "DbGetDeviceExportedListClass::execute(): arrived" << std::endl;
 	Tango::DevString argin;
 	extract(in_any, argin);
 	return insert((static_cast<DataBase *>(device))->db_get_device_exported_list(argin));
@@ -915,7 +915,7 @@ CORBA::Any *DbGetDeviceExportedListClass::execute(Tango::DeviceImpl *device, con
 //--------------------------------------------------------
 CORBA::Any *DbGetDeviceFamilyListClass::execute(Tango::DeviceImpl *device, const CORBA::Any &in_any)
 {
-	cout2 << "DbGetDeviceFamilyListClass::execute(): arrived" << endl;
+	cout2 << "DbGetDeviceFamilyListClass::execute(): arrived" << std::endl;
 	Tango::DevString argin;
 	extract(in_any, argin);
 	return insert((static_cast<DataBase *>(device))->db_get_device_family_list(argin));
@@ -934,7 +934,7 @@ CORBA::Any *DbGetDeviceFamilyListClass::execute(Tango::DeviceImpl *device, const
 //--------------------------------------------------------
 CORBA::Any *DbGetDeviceInfoClass::execute(Tango::DeviceImpl *device, const CORBA::Any &in_any)
 {
-	cout2 << "DbGetDeviceInfoClass::execute(): arrived" << endl;
+	cout2 << "DbGetDeviceInfoClass::execute(): arrived" << std::endl;
 	Tango::DevString argin;
 	extract(in_any, argin);
 	return insert((static_cast<DataBase *>(device))->db_get_device_info(argin));
@@ -953,7 +953,7 @@ CORBA::Any *DbGetDeviceInfoClass::execute(Tango::DeviceImpl *device, const CORBA
 //--------------------------------------------------------
 CORBA::Any *DbGetDeviceListClass::execute(Tango::DeviceImpl *device, const CORBA::Any &in_any)
 {
-	cout2 << "DbGetDeviceListClass::execute(): arrived" << endl;
+	cout2 << "DbGetDeviceListClass::execute(): arrived" << std::endl;
 	const Tango::DevVarStringArray *argin;
 	extract(in_any, argin);
 	return insert((static_cast<DataBase *>(device))->db_get_device_list(argin));
@@ -972,7 +972,7 @@ CORBA::Any *DbGetDeviceListClass::execute(Tango::DeviceImpl *device, const CORBA
 //--------------------------------------------------------
 CORBA::Any *DbGetDeviceWideListClass::execute(Tango::DeviceImpl *device, const CORBA::Any &in_any)
 {
-	cout2 << "DbGetDeviceWideListClass::execute(): arrived" << endl;
+	cout2 << "DbGetDeviceWideListClass::execute(): arrived" << std::endl;
 	Tango::DevString argin;
 	extract(in_any, argin);
 	return insert((static_cast<DataBase *>(device))->db_get_device_wide_list(argin));
@@ -991,7 +991,7 @@ CORBA::Any *DbGetDeviceWideListClass::execute(Tango::DeviceImpl *device, const C
 //--------------------------------------------------------
 CORBA::Any *DbGetDeviceMemberListClass::execute(Tango::DeviceImpl *device, const CORBA::Any &in_any)
 {
-	cout2 << "DbGetDeviceMemberListClass::execute(): arrived" << endl;
+	cout2 << "DbGetDeviceMemberListClass::execute(): arrived" << std::endl;
 	Tango::DevString argin;
 	extract(in_any, argin);
 	return insert((static_cast<DataBase *>(device))->db_get_device_member_list(argin));
@@ -1010,7 +1010,7 @@ CORBA::Any *DbGetDeviceMemberListClass::execute(Tango::DeviceImpl *device, const
 //--------------------------------------------------------
 CORBA::Any *DbGetDevicePropertyClass::execute(Tango::DeviceImpl *device, const CORBA::Any &in_any)
 {
-	cout2 << "DbGetDevicePropertyClass::execute(): arrived" << endl;
+	cout2 << "DbGetDevicePropertyClass::execute(): arrived" << std::endl;
 	const Tango::DevVarStringArray *argin;
 	extract(in_any, argin);
 	return insert((static_cast<DataBase *>(device))->db_get_device_property(argin));
@@ -1029,7 +1029,7 @@ CORBA::Any *DbGetDevicePropertyClass::execute(Tango::DeviceImpl *device, const C
 //--------------------------------------------------------
 CORBA::Any *DbGetDevicePropertyHistClass::execute(Tango::DeviceImpl *device, const CORBA::Any &in_any)
 {
-	cout2 << "DbGetDevicePropertyHistClass::execute(): arrived" << endl;
+	cout2 << "DbGetDevicePropertyHistClass::execute(): arrived" << std::endl;
 	const Tango::DevVarStringArray *argin;
 	extract(in_any, argin);
 	return insert((static_cast<DataBase *>(device))->db_get_device_property_hist(argin));
@@ -1048,7 +1048,7 @@ CORBA::Any *DbGetDevicePropertyHistClass::execute(Tango::DeviceImpl *device, con
 //--------------------------------------------------------
 CORBA::Any *DbGetDevicePropertyListClass::execute(Tango::DeviceImpl *device, const CORBA::Any &in_any)
 {
-	cout2 << "DbGetDevicePropertyListClass::execute(): arrived" << endl;
+	cout2 << "DbGetDevicePropertyListClass::execute(): arrived" << std::endl;
 	const Tango::DevVarStringArray *argin;
 	extract(in_any, argin);
 	return insert((static_cast<DataBase *>(device))->db_get_device_property_list(argin));
@@ -1067,7 +1067,7 @@ CORBA::Any *DbGetDevicePropertyListClass::execute(Tango::DeviceImpl *device, con
 //--------------------------------------------------------
 CORBA::Any *DbGetDeviceServerClassListClass::execute(Tango::DeviceImpl *device, const CORBA::Any &in_any)
 {
-	cout2 << "DbGetDeviceServerClassListClass::execute(): arrived" << endl;
+	cout2 << "DbGetDeviceServerClassListClass::execute(): arrived" << std::endl;
 	Tango::DevString argin;
 	extract(in_any, argin);
 	return insert((static_cast<DataBase *>(device))->db_get_device_server_class_list(argin));
@@ -1086,7 +1086,7 @@ CORBA::Any *DbGetDeviceServerClassListClass::execute(Tango::DeviceImpl *device, 
 //--------------------------------------------------------
 CORBA::Any *DbGetExportdDeviceListForClassClass::execute(Tango::DeviceImpl *device, const CORBA::Any &in_any)
 {
-	cout2 << "DbGetExportdDeviceListForClassClass::execute(): arrived" << endl;
+	cout2 << "DbGetExportdDeviceListForClassClass::execute(): arrived" << std::endl;
 	Tango::DevString argin;
 	extract(in_any, argin);
 	return insert((static_cast<DataBase *>(device))->db_get_exportd_device_list_for_class(argin));
@@ -1105,7 +1105,7 @@ CORBA::Any *DbGetExportdDeviceListForClassClass::execute(Tango::DeviceImpl *devi
 //--------------------------------------------------------
 CORBA::Any *DbGetHostListClass::execute(Tango::DeviceImpl *device, const CORBA::Any &in_any)
 {
-	cout2 << "DbGetHostListClass::execute(): arrived" << endl;
+	cout2 << "DbGetHostListClass::execute(): arrived" << std::endl;
 	Tango::DevString argin;
 	extract(in_any, argin);
 	return insert((static_cast<DataBase *>(device))->db_get_host_list(argin));
@@ -1124,7 +1124,7 @@ CORBA::Any *DbGetHostListClass::execute(Tango::DeviceImpl *device, const CORBA::
 //--------------------------------------------------------
 CORBA::Any *DbGetHostServerListClass::execute(Tango::DeviceImpl *device, const CORBA::Any &in_any)
 {
-	cout2 << "DbGetHostServerListClass::execute(): arrived" << endl;
+	cout2 << "DbGetHostServerListClass::execute(): arrived" << std::endl;
 	Tango::DevString argin;
 	extract(in_any, argin);
 	return insert((static_cast<DataBase *>(device))->db_get_host_server_list(argin));
@@ -1143,7 +1143,7 @@ CORBA::Any *DbGetHostServerListClass::execute(Tango::DeviceImpl *device, const C
 //--------------------------------------------------------
 CORBA::Any *DbGetHostServersInfoClass::execute(Tango::DeviceImpl *device, const CORBA::Any &in_any)
 {
-	cout2 << "DbGetHostServersInfoClass::execute(): arrived" << endl;
+	cout2 << "DbGetHostServersInfoClass::execute(): arrived" << std::endl;
 	Tango::DevString argin;
 	extract(in_any, argin);
 	return insert((static_cast<DataBase *>(device))->db_get_host_servers_info(argin));
@@ -1162,7 +1162,7 @@ CORBA::Any *DbGetHostServersInfoClass::execute(Tango::DeviceImpl *device, const 
 //--------------------------------------------------------
 CORBA::Any *DbGetInstanceNameListClass::execute(Tango::DeviceImpl *device, const CORBA::Any &in_any)
 {
-	cout2 << "DbGetInstanceNameListClass::execute(): arrived" << endl;
+	cout2 << "DbGetInstanceNameListClass::execute(): arrived" << std::endl;
 	Tango::DevString argin;
 	extract(in_any, argin);
 	return insert((static_cast<DataBase *>(device))->db_get_instance_name_list(argin));
@@ -1181,7 +1181,7 @@ CORBA::Any *DbGetInstanceNameListClass::execute(Tango::DeviceImpl *device, const
 //--------------------------------------------------------
 CORBA::Any *DbGetObjectListClass::execute(Tango::DeviceImpl *device, const CORBA::Any &in_any)
 {
-	cout2 << "DbGetObjectListClass::execute(): arrived" << endl;
+	cout2 << "DbGetObjectListClass::execute(): arrived" << std::endl;
 	Tango::DevString argin;
 	extract(in_any, argin);
 	return insert((static_cast<DataBase *>(device))->db_get_object_list(argin));
@@ -1200,7 +1200,7 @@ CORBA::Any *DbGetObjectListClass::execute(Tango::DeviceImpl *device, const CORBA
 //--------------------------------------------------------
 CORBA::Any *DbGetPropertyClass::execute(Tango::DeviceImpl *device, const CORBA::Any &in_any)
 {
-	cout2 << "DbGetPropertyClass::execute(): arrived" << endl;
+	cout2 << "DbGetPropertyClass::execute(): arrived" << std::endl;
 	const Tango::DevVarStringArray *argin;
 	extract(in_any, argin);
 	return insert((static_cast<DataBase *>(device))->db_get_property(argin));
@@ -1219,7 +1219,7 @@ CORBA::Any *DbGetPropertyClass::execute(Tango::DeviceImpl *device, const CORBA::
 //--------------------------------------------------------
 CORBA::Any *DbGetPropertyHistClass::execute(Tango::DeviceImpl *device, const CORBA::Any &in_any)
 {
-	cout2 << "DbGetPropertyHistClass::execute(): arrived" << endl;
+	cout2 << "DbGetPropertyHistClass::execute(): arrived" << std::endl;
 	const Tango::DevVarStringArray *argin;
 	extract(in_any, argin);
 	return insert((static_cast<DataBase *>(device))->db_get_property_hist(argin));
@@ -1238,7 +1238,7 @@ CORBA::Any *DbGetPropertyHistClass::execute(Tango::DeviceImpl *device, const COR
 //--------------------------------------------------------
 CORBA::Any *DbGetPropertyListClass::execute(Tango::DeviceImpl *device, const CORBA::Any &in_any)
 {
-	cout2 << "DbGetPropertyListClass::execute(): arrived" << endl;
+	cout2 << "DbGetPropertyListClass::execute(): arrived" << std::endl;
 	const Tango::DevVarStringArray *argin;
 	extract(in_any, argin);
 	return insert((static_cast<DataBase *>(device))->db_get_property_list(argin));
@@ -1257,7 +1257,7 @@ CORBA::Any *DbGetPropertyListClass::execute(Tango::DeviceImpl *device, const COR
 //--------------------------------------------------------
 CORBA::Any *DbGetServerInfoClass::execute(Tango::DeviceImpl *device, const CORBA::Any &in_any)
 {
-	cout2 << "DbGetServerInfoClass::execute(): arrived" << endl;
+	cout2 << "DbGetServerInfoClass::execute(): arrived" << std::endl;
 	Tango::DevString argin;
 	extract(in_any, argin);
 	return insert((static_cast<DataBase *>(device))->db_get_server_info(argin));
@@ -1276,7 +1276,7 @@ CORBA::Any *DbGetServerInfoClass::execute(Tango::DeviceImpl *device, const CORBA
 //--------------------------------------------------------
 CORBA::Any *DbGetServerListClass::execute(Tango::DeviceImpl *device, const CORBA::Any &in_any)
 {
-	cout2 << "DbGetServerListClass::execute(): arrived" << endl;
+	cout2 << "DbGetServerListClass::execute(): arrived" << std::endl;
 	Tango::DevString argin;
 	extract(in_any, argin);
 	return insert((static_cast<DataBase *>(device))->db_get_server_list(argin));
@@ -1295,7 +1295,7 @@ CORBA::Any *DbGetServerListClass::execute(Tango::DeviceImpl *device, const CORBA
 //--------------------------------------------------------
 CORBA::Any *DbGetServerNameListClass::execute(Tango::DeviceImpl *device, const CORBA::Any &in_any)
 {
-	cout2 << "DbGetServerNameListClass::execute(): arrived" << endl;
+	cout2 << "DbGetServerNameListClass::execute(): arrived" << std::endl;
 	Tango::DevString argin;
 	extract(in_any, argin);
 	return insert((static_cast<DataBase *>(device))->db_get_server_name_list(argin));
@@ -1314,7 +1314,7 @@ CORBA::Any *DbGetServerNameListClass::execute(Tango::DeviceImpl *device, const C
 //--------------------------------------------------------
 CORBA::Any *DbImportDeviceClass::execute(Tango::DeviceImpl *device, const CORBA::Any &in_any)
 {
-	cout2 << "DbImportDeviceClass::execute(): arrived" << endl;
+	cout2 << "DbImportDeviceClass::execute(): arrived" << std::endl;
 	Tango::DevString argin;
 	extract(in_any, argin);
 	return insert((static_cast<DataBase *>(device))->db_import_device(argin));
@@ -1333,7 +1333,7 @@ CORBA::Any *DbImportDeviceClass::execute(Tango::DeviceImpl *device, const CORBA:
 //--------------------------------------------------------
 CORBA::Any *DbImportEventClass::execute(Tango::DeviceImpl *device, const CORBA::Any &in_any)
 {
-	cout2 << "DbImportEventClass::execute(): arrived" << endl;
+	cout2 << "DbImportEventClass::execute(): arrived" << std::endl;
 	Tango::DevString argin;
 	extract(in_any, argin);
 	return insert((static_cast<DataBase *>(device))->db_import_event(argin));
@@ -1352,7 +1352,7 @@ CORBA::Any *DbImportEventClass::execute(Tango::DeviceImpl *device, const CORBA::
 //--------------------------------------------------------
 CORBA::Any *DbInfoClass::execute(Tango::DeviceImpl *device, TANGO_UNUSED(const CORBA::Any &in_any))
 {
-	cout2 << "DbInfoClass::execute(): arrived" << endl;
+	cout2 << "DbInfoClass::execute(): arrived" << std::endl;
 	return insert((static_cast<DataBase *>(device))->db_info());
 }
 
@@ -1369,7 +1369,7 @@ CORBA::Any *DbInfoClass::execute(Tango::DeviceImpl *device, TANGO_UNUSED(const C
 //--------------------------------------------------------
 CORBA::Any *DbPutAttributeAliasClass::execute(Tango::DeviceImpl *device, const CORBA::Any &in_any)
 {
-	cout2 << "DbPutAttributeAliasClass::execute(): arrived" << endl;
+	cout2 << "DbPutAttributeAliasClass::execute(): arrived" << std::endl;
 	const Tango::DevVarStringArray *argin;
 	extract(in_any, argin);
 	((static_cast<DataBase *>(device))->db_put_attribute_alias(argin));
@@ -1389,7 +1389,7 @@ CORBA::Any *DbPutAttributeAliasClass::execute(Tango::DeviceImpl *device, const C
 //--------------------------------------------------------
 CORBA::Any *DbPutClassAttributePropertyClass::execute(Tango::DeviceImpl *device, const CORBA::Any &in_any)
 {
-	cout2 << "DbPutClassAttributePropertyClass::execute(): arrived" << endl;
+	cout2 << "DbPutClassAttributePropertyClass::execute(): arrived" << std::endl;
 	const Tango::DevVarStringArray *argin;
 	extract(in_any, argin);
 	((static_cast<DataBase *>(device))->db_put_class_attribute_property(argin));
@@ -1409,7 +1409,7 @@ CORBA::Any *DbPutClassAttributePropertyClass::execute(Tango::DeviceImpl *device,
 //--------------------------------------------------------
 CORBA::Any *DbPutClassAttributeProperty2Class::execute(Tango::DeviceImpl *device, const CORBA::Any &in_any)
 {
-	cout2 << "DbPutClassAttributeProperty2Class::execute(): arrived" << endl;
+	cout2 << "DbPutClassAttributeProperty2Class::execute(): arrived" << std::endl;
 	const Tango::DevVarStringArray *argin;
 	extract(in_any, argin);
 	((static_cast<DataBase *>(device))->db_put_class_attribute_property2(argin));
@@ -1429,7 +1429,7 @@ CORBA::Any *DbPutClassAttributeProperty2Class::execute(Tango::DeviceImpl *device
 //--------------------------------------------------------
 CORBA::Any *DbPutClassPropertyClass::execute(Tango::DeviceImpl *device, const CORBA::Any &in_any)
 {
-	cout2 << "DbPutClassPropertyClass::execute(): arrived" << endl;
+	cout2 << "DbPutClassPropertyClass::execute(): arrived" << std::endl;
 	const Tango::DevVarStringArray *argin;
 	extract(in_any, argin);
 	((static_cast<DataBase *>(device))->db_put_class_property(argin));
@@ -1449,7 +1449,7 @@ CORBA::Any *DbPutClassPropertyClass::execute(Tango::DeviceImpl *device, const CO
 //--------------------------------------------------------
 CORBA::Any *DbPutDeviceAliasClass::execute(Tango::DeviceImpl *device, const CORBA::Any &in_any)
 {
-	cout2 << "DbPutDeviceAliasClass::execute(): arrived" << endl;
+	cout2 << "DbPutDeviceAliasClass::execute(): arrived" << std::endl;
 	const Tango::DevVarStringArray *argin;
 	extract(in_any, argin);
 	((static_cast<DataBase *>(device))->db_put_device_alias(argin));
@@ -1469,7 +1469,7 @@ CORBA::Any *DbPutDeviceAliasClass::execute(Tango::DeviceImpl *device, const CORB
 //--------------------------------------------------------
 CORBA::Any *DbPutDeviceAttributePropertyClass::execute(Tango::DeviceImpl *device, const CORBA::Any &in_any)
 {
-	cout2 << "DbPutDeviceAttributePropertyClass::execute(): arrived" << endl;
+	cout2 << "DbPutDeviceAttributePropertyClass::execute(): arrived" << std::endl;
 	const Tango::DevVarStringArray *argin;
 	extract(in_any, argin);
 	((static_cast<DataBase *>(device))->db_put_device_attribute_property(argin));
@@ -1489,7 +1489,7 @@ CORBA::Any *DbPutDeviceAttributePropertyClass::execute(Tango::DeviceImpl *device
 //--------------------------------------------------------
 CORBA::Any *DbPutDeviceAttributeProperty2Class::execute(Tango::DeviceImpl *device, const CORBA::Any &in_any)
 {
-	cout2 << "DbPutDeviceAttributeProperty2Class::execute(): arrived" << endl;
+	cout2 << "DbPutDeviceAttributeProperty2Class::execute(): arrived" << std::endl;
 	const Tango::DevVarStringArray *argin;
 	extract(in_any, argin);
 	((static_cast<DataBase *>(device))->db_put_device_attribute_property2(argin));
@@ -1509,7 +1509,7 @@ CORBA::Any *DbPutDeviceAttributeProperty2Class::execute(Tango::DeviceImpl *devic
 //--------------------------------------------------------
 CORBA::Any *DbPutDevicePropertyClass::execute(Tango::DeviceImpl *device, const CORBA::Any &in_any)
 {
-	cout2 << "DbPutDevicePropertyClass::execute(): arrived" << endl;
+	cout2 << "DbPutDevicePropertyClass::execute(): arrived" << std::endl;
 	const Tango::DevVarStringArray *argin;
 	extract(in_any, argin);
 	((static_cast<DataBase *>(device))->db_put_device_property(argin));
@@ -1529,7 +1529,7 @@ CORBA::Any *DbPutDevicePropertyClass::execute(Tango::DeviceImpl *device, const C
 //--------------------------------------------------------
 CORBA::Any *DbPutPropertyClass::execute(Tango::DeviceImpl *device, const CORBA::Any &in_any)
 {
-	cout2 << "DbPutPropertyClass::execute(): arrived" << endl;
+	cout2 << "DbPutPropertyClass::execute(): arrived" << std::endl;
 	const Tango::DevVarStringArray *argin;
 	extract(in_any, argin);
 	((static_cast<DataBase *>(device))->db_put_property(argin));
@@ -1549,7 +1549,7 @@ CORBA::Any *DbPutPropertyClass::execute(Tango::DeviceImpl *device, const CORBA::
 //--------------------------------------------------------
 CORBA::Any *DbPutServerInfoClass::execute(Tango::DeviceImpl *device, const CORBA::Any &in_any)
 {
-	cout2 << "DbPutServerInfoClass::execute(): arrived" << endl;
+	cout2 << "DbPutServerInfoClass::execute(): arrived" << std::endl;
 	const Tango::DevVarStringArray *argin;
 	extract(in_any, argin);
 	((static_cast<DataBase *>(device))->db_put_server_info(argin));
@@ -1569,7 +1569,7 @@ CORBA::Any *DbPutServerInfoClass::execute(Tango::DeviceImpl *device, const CORBA
 //--------------------------------------------------------
 CORBA::Any *DbUnExportDeviceClass::execute(Tango::DeviceImpl *device, const CORBA::Any &in_any)
 {
-	cout2 << "DbUnExportDeviceClass::execute(): arrived" << endl;
+	cout2 << "DbUnExportDeviceClass::execute(): arrived" << std::endl;
 	Tango::DevString argin;
 	extract(in_any, argin);
 	((static_cast<DataBase *>(device))->db_un_export_device(argin));
@@ -1589,7 +1589,7 @@ CORBA::Any *DbUnExportDeviceClass::execute(Tango::DeviceImpl *device, const CORB
 //--------------------------------------------------------
 CORBA::Any *DbUnExportEventClass::execute(Tango::DeviceImpl *device, const CORBA::Any &in_any)
 {
-	cout2 << "DbUnExportEventClass::execute(): arrived" << endl;
+	cout2 << "DbUnExportEventClass::execute(): arrived" << std::endl;
 	Tango::DevString argin;
 	extract(in_any, argin);
 	((static_cast<DataBase *>(device))->db_un_export_event(argin));
@@ -1609,7 +1609,7 @@ CORBA::Any *DbUnExportEventClass::execute(Tango::DeviceImpl *device, const CORBA
 //--------------------------------------------------------
 CORBA::Any *DbUnExportServerClass::execute(Tango::DeviceImpl *device, const CORBA::Any &in_any)
 {
-	cout2 << "DbUnExportServerClass::execute(): arrived" << endl;
+	cout2 << "DbUnExportServerClass::execute(): arrived" << std::endl;
 	Tango::DevString argin;
 	extract(in_any, argin);
 	((static_cast<DataBase *>(device))->db_un_export_server(argin));
@@ -1629,7 +1629,7 @@ CORBA::Any *DbUnExportServerClass::execute(Tango::DeviceImpl *device, const CORB
 //--------------------------------------------------------
 CORBA::Any *ResetTimingValuesClass::execute(Tango::DeviceImpl *device, TANGO_UNUSED(const CORBA::Any &in_any))
 {
-	cout2 << "ResetTimingValuesClass::execute(): arrived" << endl;
+	cout2 << "ResetTimingValuesClass::execute(): arrived" << std::endl;
 	((static_cast<DataBase *>(device))->reset_timing_values());
 	return new CORBA::Any();
 }
@@ -1647,7 +1647,7 @@ CORBA::Any *ResetTimingValuesClass::execute(Tango::DeviceImpl *device, TANGO_UNU
 //--------------------------------------------------------
 CORBA::Any *DbGetDataForServerCacheClass::execute(Tango::DeviceImpl *device, const CORBA::Any &in_any)
 {
-	cout2 << "DbGetDataForServerCacheClass::execute(): arrived" << endl;
+	cout2 << "DbGetDataForServerCacheClass::execute(): arrived" << std::endl;
 	const Tango::DevVarStringArray *argin;
 	extract(in_any, argin);
 	return insert((static_cast<DataBase *>(device))->db_get_data_for_server_cache(argin));
@@ -1666,7 +1666,7 @@ CORBA::Any *DbGetDataForServerCacheClass::execute(Tango::DeviceImpl *device, con
 //--------------------------------------------------------
 CORBA::Any *DbDeleteAllDeviceAttributePropertyClass::execute(Tango::DeviceImpl *device, const CORBA::Any &in_any)
 {
-	cout2 << "DbDeleteAllDeviceAttributePropertyClass::execute(): arrived" << endl;
+	cout2 << "DbDeleteAllDeviceAttributePropertyClass::execute(): arrived" << std::endl;
 	const Tango::DevVarStringArray *argin;
 	extract(in_any, argin);
 	((static_cast<DataBase *>(device))->db_delete_all_device_attribute_property(argin));
@@ -1686,7 +1686,7 @@ CORBA::Any *DbDeleteAllDeviceAttributePropertyClass::execute(Tango::DeviceImpl *
 //--------------------------------------------------------
 CORBA::Any *DbMySqlSelectClass::execute(Tango::DeviceImpl *device, const CORBA::Any &in_any)
 {
-	cout2 << "DbMySqlSelectClass::execute(): arrived" << endl;
+	cout2 << "DbMySqlSelectClass::execute(): arrived" << std::endl;
 	Tango::DevString argin;
 	extract(in_any, argin);
 	return insert((static_cast<DataBase *>(device))->db_my_sql_select(argin));
@@ -1705,7 +1705,7 @@ CORBA::Any *DbMySqlSelectClass::execute(Tango::DeviceImpl *device, const CORBA::
 //--------------------------------------------------------
 CORBA::Any *DbGetCSDbServerListClass::execute(Tango::DeviceImpl *device, TANGO_UNUSED(const CORBA::Any &in_any))
 {
-	cout2 << "DbGetCSDbServerListClass::execute(): arrived" << endl;
+	cout2 << "DbGetCSDbServerListClass::execute(): arrived" << std::endl;
 	return insert((static_cast<DataBase *>(device))->db_get_csdb_server_list());
 }
 
@@ -1722,7 +1722,7 @@ CORBA::Any *DbGetCSDbServerListClass::execute(Tango::DeviceImpl *device, TANGO_U
 //--------------------------------------------------------
 CORBA::Any *DbGetAttributeAlias2Class::execute(Tango::DeviceImpl *device, const CORBA::Any &in_any)
 {
-	cout2 << "DbGetAttributeAlias2Class::execute(): arrived" << endl;
+	cout2 << "DbGetAttributeAlias2Class::execute(): arrived" << std::endl;
 	Tango::DevString argin;
 	extract(in_any, argin);
 	return insert((static_cast<DataBase *>(device))->db_get_attribute_alias2(argin));
@@ -1741,7 +1741,7 @@ CORBA::Any *DbGetAttributeAlias2Class::execute(Tango::DeviceImpl *device, const 
 //--------------------------------------------------------
 CORBA::Any *DbGetAliasAttributeClass::execute(Tango::DeviceImpl *device, const CORBA::Any &in_any)
 {
-	cout2 << "DbGetAliasAttributeClass::execute(): arrived" << endl;
+	cout2 << "DbGetAliasAttributeClass::execute(): arrived" << std::endl;
 	Tango::DevString argin;
 	extract(in_any, argin);
 	return insert((static_cast<DataBase *>(device))->db_get_alias_attribute(argin));
@@ -1760,7 +1760,7 @@ CORBA::Any *DbGetAliasAttributeClass::execute(Tango::DeviceImpl *device, const C
 //--------------------------------------------------------
 CORBA::Any *DbRenameServerClass::execute(Tango::DeviceImpl *device, const CORBA::Any &in_any)
 {
-	cout2 << "DbRenameServerClass::execute(): arrived" << endl;
+	cout2 << "DbRenameServerClass::execute(): arrived" << std::endl;
 	const Tango::DevVarStringArray *argin;
 	extract(in_any, argin);
 	((static_cast<DataBase *>(device))->db_rename_server(argin));
@@ -1780,7 +1780,7 @@ CORBA::Any *DbRenameServerClass::execute(Tango::DeviceImpl *device, const CORBA:
 //--------------------------------------------------------
 CORBA::Any *DbGetClassPipePropertyClass::execute(Tango::DeviceImpl *device, const CORBA::Any &in_any)
 {
-	cout2 << "DbGetClassPipePropertyClass::execute(): arrived" << endl;
+	cout2 << "DbGetClassPipePropertyClass::execute(): arrived" << std::endl;
 	const Tango::DevVarStringArray *argin;
 	extract(in_any, argin);
 	return insert((static_cast<DataBase *>(device))->db_get_class_pipe_property(argin));
@@ -1799,7 +1799,7 @@ CORBA::Any *DbGetClassPipePropertyClass::execute(Tango::DeviceImpl *device, cons
 //--------------------------------------------------------
 CORBA::Any *DbGetDevicePipePropertyClass::execute(Tango::DeviceImpl *device, const CORBA::Any &in_any)
 {
-	cout2 << "DbGetDevicePipePropertyClass::execute(): arrived" << endl;
+	cout2 << "DbGetDevicePipePropertyClass::execute(): arrived" << std::endl;
 	const Tango::DevVarStringArray *argin;
 	extract(in_any, argin);
 	return insert((static_cast<DataBase *>(device))->db_get_device_pipe_property(argin));
@@ -1818,7 +1818,7 @@ CORBA::Any *DbGetDevicePipePropertyClass::execute(Tango::DeviceImpl *device, con
 //--------------------------------------------------------
 CORBA::Any *DbDeleteClassPipeClass::execute(Tango::DeviceImpl *device, const CORBA::Any &in_any)
 {
-	cout2 << "DbDeleteClassPipeClass::execute(): arrived" << endl;
+	cout2 << "DbDeleteClassPipeClass::execute(): arrived" << std::endl;
 	const Tango::DevVarStringArray *argin;
 	extract(in_any, argin);
 	((static_cast<DataBase *>(device))->db_delete_class_pipe(argin));
@@ -1838,7 +1838,7 @@ CORBA::Any *DbDeleteClassPipeClass::execute(Tango::DeviceImpl *device, const COR
 //--------------------------------------------------------
 CORBA::Any *DbDeleteDevicePipeClass::execute(Tango::DeviceImpl *device, const CORBA::Any &in_any)
 {
-	cout2 << "DbDeleteDevicePipeClass::execute(): arrived" << endl;
+	cout2 << "DbDeleteDevicePipeClass::execute(): arrived" << std::endl;
 	const Tango::DevVarStringArray *argin;
 	extract(in_any, argin);
 	((static_cast<DataBase *>(device))->db_delete_device_pipe(argin));
@@ -1858,7 +1858,7 @@ CORBA::Any *DbDeleteDevicePipeClass::execute(Tango::DeviceImpl *device, const CO
 //--------------------------------------------------------
 CORBA::Any *DbDeleteClassPipePropertyClass::execute(Tango::DeviceImpl *device, const CORBA::Any &in_any)
 {
-	cout2 << "DbDeleteClassPipePropertyClass::execute(): arrived" << endl;
+	cout2 << "DbDeleteClassPipePropertyClass::execute(): arrived" << std::endl;
 	const Tango::DevVarStringArray *argin;
 	extract(in_any, argin);
 	((static_cast<DataBase *>(device))->db_delete_class_pipe_property(argin));
@@ -1878,7 +1878,7 @@ CORBA::Any *DbDeleteClassPipePropertyClass::execute(Tango::DeviceImpl *device, c
 //--------------------------------------------------------
 CORBA::Any *DbDeleteDevicePipePropertyClass::execute(Tango::DeviceImpl *device, const CORBA::Any &in_any)
 {
-	cout2 << "DbDeleteDevicePipePropertyClass::execute(): arrived" << endl;
+	cout2 << "DbDeleteDevicePipePropertyClass::execute(): arrived" << std::endl;
 	const Tango::DevVarStringArray *argin;
 	extract(in_any, argin);
 	((static_cast<DataBase *>(device))->db_delete_device_pipe_property(argin));
@@ -1898,7 +1898,7 @@ CORBA::Any *DbDeleteDevicePipePropertyClass::execute(Tango::DeviceImpl *device, 
 //--------------------------------------------------------
 CORBA::Any *DbGetClassPipeListClass::execute(Tango::DeviceImpl *device, const CORBA::Any &in_any)
 {
-	cout2 << "DbGetClassPipeListClass::execute(): arrived" << endl;
+	cout2 << "DbGetClassPipeListClass::execute(): arrived" << std::endl;
 	const Tango::DevVarStringArray *argin;
 	extract(in_any, argin);
 	return insert((static_cast<DataBase *>(device))->db_get_class_pipe_list(argin));
@@ -1917,7 +1917,7 @@ CORBA::Any *DbGetClassPipeListClass::execute(Tango::DeviceImpl *device, const CO
 //--------------------------------------------------------
 CORBA::Any *DbGetDevicePipeListClass::execute(Tango::DeviceImpl *device, const CORBA::Any &in_any)
 {
-	cout2 << "DbGetDevicePipeListClass::execute(): arrived" << endl;
+	cout2 << "DbGetDevicePipeListClass::execute(): arrived" << std::endl;
 	const Tango::DevVarStringArray *argin;
 	extract(in_any, argin);
 	return insert((static_cast<DataBase *>(device))->db_get_device_pipe_list(argin));
@@ -1936,7 +1936,7 @@ CORBA::Any *DbGetDevicePipeListClass::execute(Tango::DeviceImpl *device, const C
 //--------------------------------------------------------
 CORBA::Any *DbDeleteAllDevicePipePropertyClass::execute(Tango::DeviceImpl *device, const CORBA::Any &in_any)
 {
-	cout2 << "DbDeleteAllDevicePipePropertyClass::execute(): arrived" << endl;
+	cout2 << "DbDeleteAllDevicePipePropertyClass::execute(): arrived" << std::endl;
 	const Tango::DevVarStringArray *argin;
 	extract(in_any, argin);
 	((static_cast<DataBase *>(device))->db_delete_all_device_pipe_property(argin));
@@ -1956,7 +1956,7 @@ CORBA::Any *DbDeleteAllDevicePipePropertyClass::execute(Tango::DeviceImpl *devic
 //--------------------------------------------------------
 CORBA::Any *DbPutClassPipePropertyClass::execute(Tango::DeviceImpl *device, const CORBA::Any &in_any)
 {
-	cout2 << "DbPutClassPipePropertyClass::execute(): arrived" << endl;
+	cout2 << "DbPutClassPipePropertyClass::execute(): arrived" << std::endl;
 	const Tango::DevVarStringArray *argin;
 	extract(in_any, argin);
 	((static_cast<DataBase *>(device))->db_put_class_pipe_property(argin));
@@ -1976,7 +1976,7 @@ CORBA::Any *DbPutClassPipePropertyClass::execute(Tango::DeviceImpl *device, cons
 //--------------------------------------------------------
 CORBA::Any *DbPutDevicePipePropertyClass::execute(Tango::DeviceImpl *device, const CORBA::Any &in_any)
 {
-	cout2 << "DbPutDevicePipePropertyClass::execute(): arrived" << endl;
+	cout2 << "DbPutDevicePipePropertyClass::execute(): arrived" << std::endl;
 	const Tango::DevVarStringArray *argin;
 	extract(in_any, argin);
 	((static_cast<DataBase *>(device))->db_put_device_pipe_property(argin));
@@ -1996,7 +1996,7 @@ CORBA::Any *DbPutDevicePipePropertyClass::execute(Tango::DeviceImpl *device, con
 //--------------------------------------------------------
 CORBA::Any *DbGetClassPipePropertyHistClass::execute(Tango::DeviceImpl *device, const CORBA::Any &in_any)
 {
-	cout2 << "DbGetClassPipePropertyHistClass::execute(): arrived" << endl;
+	cout2 << "DbGetClassPipePropertyHistClass::execute(): arrived" << std::endl;
 	const Tango::DevVarStringArray *argin;
 	extract(in_any, argin);
 	return insert((static_cast<DataBase *>(device))->db_get_class_pipe_property_hist(argin));
@@ -2015,7 +2015,7 @@ CORBA::Any *DbGetClassPipePropertyHistClass::execute(Tango::DeviceImpl *device, 
 //--------------------------------------------------------
 CORBA::Any *DbGetDevicePipePropertyHistClass::execute(Tango::DeviceImpl *device, const CORBA::Any &in_any)
 {
-	cout2 << "DbGetDevicePipePropertyHistClass::execute(): arrived" << endl;
+	cout2 << "DbGetDevicePipePropertyHistClass::execute(): arrived" << std::endl;
 	const Tango::DevVarStringArray *argin;
 	extract(in_any, argin);
 	return insert((static_cast<DataBase *>(device))->db_get_device_pipe_property_hist(argin));
@@ -2034,7 +2034,7 @@ CORBA::Any *DbGetDevicePipePropertyHistClass::execute(Tango::DeviceImpl *device,
 //--------------------------------------------------------
 CORBA::Any *DbGetForwardedAttributeListForDeviceClass::execute(Tango::DeviceImpl *device, const CORBA::Any &in_any)
 {
-	cout2 << "DbGetForwardedAttributeListForDeviceClass::execute(): arrived" << endl;
+	cout2 << "DbGetForwardedAttributeListForDeviceClass::execute(): arrived" << std::endl;
 	Tango::DevString argin;
 	extract(in_any, argin);
 	return insert((static_cast<DataBase *>(device))->db_get_forwarded_attribute_list_for_device(argin));
@@ -2050,7 +2050,7 @@ CORBA::Any *DbGetForwardedAttributeListForDeviceClass::execute(Tango::DeviceImpl
  *	Description : Get the class property for specified name.
  */
 //--------------------------------------------------------
-Tango::DbDatum DataBaseClass::get_class_property(string &prop_name)
+Tango::DbDatum DataBaseClass::get_class_property(std::string &prop_name)
 {
 	for (unsigned int i=0 ; i<cl_prop.size() ; i++)
 		if (cl_prop[i].name == prop_name)
@@ -2065,7 +2065,7 @@ Tango::DbDatum DataBaseClass::get_class_property(string &prop_name)
  *	Description : Return the default value for device property.
  */
 //--------------------------------------------------------
-Tango::DbDatum DataBaseClass::get_default_device_property(string &prop_name)
+Tango::DbDatum DataBaseClass::get_default_device_property(std::string &prop_name)
 {
 	for (unsigned int i=0 ; i<dev_def_prop.size() ; i++)
 		if (dev_def_prop[i].name == prop_name)
@@ -2080,7 +2080,7 @@ Tango::DbDatum DataBaseClass::get_default_device_property(string &prop_name)
  *	Description : Return the default value for class property.
  */
 //--------------------------------------------------------
-Tango::DbDatum DataBaseClass::get_default_class_property(string &prop_name)
+Tango::DbDatum DataBaseClass::get_default_class_property(std::string &prop_name)
 {
 	for (unsigned int i=0 ; i<cl_def_prop.size() ; i++)
 		if (cl_def_prop[i].name == prop_name)
@@ -2101,10 +2101,10 @@ Tango::DbDatum DataBaseClass::get_default_class_property(string &prop_name)
 //--------------------------------------------------------
 void DataBaseClass::set_default_property()
 {
-	string	prop_name;
-	string	prop_desc;
-	string	prop_def;
-	vector<string>	vect_data;
+	std::string	prop_name;
+	std::string	prop_desc;
+	std::string	prop_def;
+	std::vector<std::string>	vect_data;
 
 	//	Set Default Class Properties
 
@@ -2124,124 +2124,26 @@ void DataBaseClass::write_class_property()
 		return;
 
 	Tango::DbData	data;
-	string	classname = get_name();
-	string	header;
-	string::size_type	start, end;
+	std::string	classname = get_name();
+	std::string	header;
+	std::string::size_type	start, end;
 
 	//	Put title
 	Tango::DbDatum	title("ProjectTitle");
-	string	str_title("TANGO");
+	std::string	str_title("TANGO");
 	title << str_title;
 	data.push_back(title);
 
 	//	Put Description
 	Tango::DbDatum	description("Description");
-	vector<string>	str_desc;
+	std::vector<std::string>	str_desc;
 	str_desc.push_back("This class manage the TANGO database.");
 	description << str_desc;
 	data.push_back(description);
 
-	//	put cvs or svn location
-	string	filename("DataBase");
-	filename += "Class.cpp";
-
-	// check for cvs information
-	string	src_path(CvsPath);
-	start = src_path.find("/");
-	if (start!=string::npos)
-	{
-		end   = src_path.find(filename);
-		if (end>start)
-		{
-			string	strloc = src_path.substr(start, end-start);
-			//	Check if specific repository
-			start = strloc.find("/cvsroot/");
-			if (start!=string::npos && start>0)
-			{
-				string	repository = strloc.substr(0, start);
-				if (repository.find("/segfs/")!=string::npos)
-					strloc = "ESRF:" + strloc.substr(start, strloc.length()-start);
-			}
-			Tango::DbDatum	cvs_loc("cvs_location");
-			cvs_loc << strloc;
-			data.push_back(cvs_loc);
-		}
-	}
-
-	// check for svn information
-	else
-	{
-		string	src_path(SvnPath);
-		start = src_path.find("://");
-		if (start!=string::npos)
-		{
-			end = src_path.find(filename);
-			if (end>start)
-			{
-				header = "$HeadURL: ";
-				start = header.length();
-				string	strloc = src_path.substr(start, (end-start));
-				
-				Tango::DbDatum	svn_loc("svn_location");
-				svn_loc << strloc;
-				data.push_back(svn_loc);
-			}
-		}
-	}
-
-	//	Get CVS or SVN revision tag
-	
-	// CVS tag
-	string	tagname(TagName);
-	header = "$Name: ";
-	start = header.length();
-	string	endstr(" $");
-	
-	end   = tagname.find(endstr);
-	if (end!=string::npos && end>start)
-	{
-		string	strtag = tagname.substr(start, end-start);
-		Tango::DbDatum	cvs_tag("cvs_tag");
-		cvs_tag << strtag;
-		data.push_back(cvs_tag);
-	}
-	
-	// SVN tag
-	string	svnpath(SvnPath);
-	header = "$HeadURL: ";
-	start = header.length();
-	
-	end   = svnpath.find(endstr);
-	if (end!=string::npos && end>start)
-	{
-		string	strloc = svnpath.substr(start, end-start);
-		
-		string tagstr ("/tags/");
-		start = strloc.find(tagstr);
-		if ( start!=string::npos )
-		{
-			start = start + tagstr.length();
-			end   = strloc.find(filename);
-			string	strtag = strloc.substr(start, end-start-1);
-			
-			Tango::DbDatum	svn_tag("svn_tag");
-			svn_tag << strtag;
-			data.push_back(svn_tag);
-		}
-	}
-
-	//	Get URL location
-	string	httpServ(HttpServer);
-	if (httpServ.length()>0)
-	{
-		Tango::DbDatum	db_doc_url("doc_url");
-		db_doc_url << httpServ;
-		data.push_back(db_doc_url);
-	}
-
 	//  Put inheritance
 	Tango::DbDatum	inher_datum("InheritedFrom");
-	vector<string> inheritance;
+	std::vector<std::string> inheritance;
 	inheritance.push_back("TANGO_BASE_CLASS");
 	inher_datum << inheritance;
 	data.push_back(inher_datum);
@@ -2274,7 +2176,7 @@ export_device(device_list[0],"database");
  *                and store them in the attribute list
  */
 //--------------------------------------------------------
-void DataBaseClass::attribute_factory(vector<Tango::Attr *> &att_list)
+void DataBaseClass::attribute_factory(std::vector<Tango::Attr *> &att_list)
 {
 	/*----- PROTECTED REGION ID(DataBaseClass::attribute_factory_before) ENABLED START -----*/
 
@@ -3382,16 +3284,16 @@ void DataBaseClass::command_factory()
  * @param	att_list	the ceated attribute list
  */
 //--------------------------------------------------------
-void DataBaseClass::create_static_attribute_list(vector<Tango::Attr *> &att_list)
+void DataBaseClass::create_static_attribute_list(std::vector<Tango::Attr *> &att_list)
 {
 	for (unsigned long i=0 ; i<att_list.size() ; i++)
 	{
-		string att_name(att_list[i]->get_name());
+		std::string att_name(att_list[i]->get_name());
 		transform(att_name.begin(), att_name.end(), att_name.begin(), ::tolower);
 		defaultAttList.push_back(att_name);
 	}
 
-	cout2 << defaultAttList.size() << " attributes in default list" << endl;
+	cout2 << defaultAttList.size() << " attributes in default list" << std::endl;
 
 	/*----- PROTECTED REGION ID(DataBaseClass::create_static_att_list) ENABLED START -----*/
 
@@ -3408,26 +3310,26 @@ void DataBaseClass::create_static_attribute_list(vector<Tango::Attr *> &att_list
  * @param	list of all attributes
  */
 //--------------------------------------------------------
-void DataBaseClass::erase_dynamic_attributes(const Tango::DevVarStringArray *devlist_ptr, vector<Tango::Attr *> &att_list)
+void DataBaseClass::erase_dynamic_attributes(const Tango::DevVarStringArray *devlist_ptr, std::vector<Tango::Attr *> &att_list)
 {
 	Tango::Util *tg = Tango::Util::instance();
 
 	for (unsigned long i=0 ; i<devlist_ptr->length() ; i++)
 	{
-		Tango::DeviceImpl *dev_impl = tg->get_device_by_name(((string)(*devlist_ptr)[i]).c_str());
+		Tango::DeviceImpl *dev_impl = tg->get_device_by_name(((std::string)(*devlist_ptr)[i]).c_str());
 		DataBase *dev = static_cast<DataBase *> (dev_impl);
 
-		vector<Tango::Attribute *> &dev_att_list = dev->get_device_attr()->get_attribute_list();
-		vector<Tango::Attribute *>::iterator ite_att;
+		std::vector<Tango::Attribute *> &dev_att_list = dev->get_device_attr()->get_attribute_list();
+		std::vector<Tango::Attribute *>::iterator ite_att;
 		for (ite_att=dev_att_list.begin() ; ite_att != dev_att_list.end() ; ++ite_att)
 		{
-			string att_name((*ite_att)->get_name_lower());
+			std::string att_name((*ite_att)->get_name_lower());
 			if ((att_name == "state") || (att_name == "status"))
 				continue;
-			vector<string>::iterator ite_str = find(defaultAttList.begin(), defaultAttList.end(), att_name);
+			std::vector<std::string>::iterator ite_str = find(defaultAttList.begin(), defaultAttList.end(), att_name);
 			if (ite_str == defaultAttList.end())
 			{
-				cout2 << att_name << " is a UNWANTED dynamic attribute for device " << (*devlist_ptr)[i] << endl;
+				cout2 << att_name << " is a UNWANTED dynamic attribute for device " << (*devlist_ptr)[i] << std::endl;
 				Tango::Attribute &att = dev->get_device_attr()->get_attr_by_name(att_name.c_str());
 				dev->remove_attribute(att_list[att.get_attr_idx()], true, false);
 				--ite_att;
@@ -3441,13 +3343,13 @@ void DataBaseClass::erase_dynamic_attributes(const Tango::DevVarStringArray *dev
 
 //--------------------------------------------------------
 /**
- *	Method      : DataBaseClass::get_attr_by_name()
+ *	Method      : DataBaseClass::get_attr_object_by_name()
  *	Description : returns Tango::Attr * object found by name
  */
 //--------------------------------------------------------
-Tango::Attr *DataBaseClass::get_attr_object_by_name(vector<Tango::Attr *> &att_list, string attname)
+Tango::Attr *DataBaseClass::get_attr_object_by_name(std::vector<Tango::Attr *> &att_list, std::string attname)
 {
-	vector<Tango::Attr *>::iterator it;
+	std::vector<Tango::Attr *>::iterator it;
 	for (it=att_list.begin() ; it<att_list.end() ; ++it)
 		if ((*it)->get_name()==attname)
 			return (*it);

--- a/DataBaseClass.h
+++ b/DataBaseClass.h
@@ -2415,28 +2415,28 @@ public:
 		static DataBaseClass *init(const char *);
 		static DataBaseClass *instance();
 		~DataBaseClass();
-		Tango::DbDatum	get_class_property(string &);
-		Tango::DbDatum	get_default_device_property(string &);
-		Tango::DbDatum	get_default_class_property(string &);
+		Tango::DbDatum	get_class_property(std::string &);
+		Tango::DbDatum	get_default_device_property(std::string &);
+		Tango::DbDatum	get_default_class_property(std::string &);
 	
 	protected:
-		DataBaseClass(string &);
+		DataBaseClass(std::string &);
 		static DataBaseClass *_instance;
 		void command_factory();
-		void attribute_factory(vector<Tango::Attr *> &);
+		void attribute_factory(std::vector<Tango::Attr *> &);
 		void pipe_factory();
 		void write_class_property();
 		void set_default_property();
 		void get_class_property();
-		string get_cvstag();
-		string get_cvsroot();
+		std::string get_cvstag();
+		std::string get_cvsroot();
 	
 	private:
 		void device_factory(const Tango::DevVarStringArray *);
-		void create_static_attribute_list(vector<Tango::Attr *> &);
-		void erase_dynamic_attributes(const Tango::DevVarStringArray *,vector<Tango::Attr *> &);
-		vector<string>	defaultAttList;
-		Tango::Attr *get_attr_object_by_name(vector<Tango::Attr *> &att_list, string attname);
+		void create_static_attribute_list(std::vector<Tango::Attr *> &);
+		void erase_dynamic_attributes(const Tango::DevVarStringArray *,std::vector<Tango::Attr *> &);
+		std::vector<std::string>	defaultAttList;
+		Tango::Attr *get_attr_object_by_name(std::vector<Tango::Attr *> &att_list, std::string attname);
 };
 
 }	//	End of namespace

--- a/DataBaseUtils.cpp
+++ b/DataBaseUtils.cpp
@@ -849,7 +849,7 @@ void DataBase::create_connection_pool(const char *mysql_user,
 			ho = my_host.substr(0,pos);
 			pos++;
 			port = my_host.substr(pos);
-			stringstream ss(port);
+			std::stringstream ss(port);
 			ss >> port_num;
 			if (!ss)
 				port_num = 0;
@@ -1088,7 +1088,7 @@ bool DataBase::host_port_from_ior(const char *iorstr,string &h_p)
 // Add port number
 //
 
-				stringstream ss;
+				std::stringstream ss;
 				ss << pBody.address.port;
 				h_p = h_p + ss.str();
 

--- a/DataBaseUtils.cpp
+++ b/DataBaseUtils.cpp
@@ -74,16 +74,16 @@ namespace DataBase_ns {
 // out :		void - nothing
 //
 //-----------------------------------------------------------------------------
-string DataBase::replace_wildcard(const char *wildcard_c_str)
+std::string DataBase::replace_wildcard(const char *wildcard_c_str)
 {
-	string wildcard(wildcard_c_str);
-	string::size_type index;
+	std::string wildcard(wildcard_c_str);
+	std::string::size_type index;
 
 	DEBUG_STREAM << "DataBase::replace_wildcard() wildcard in " << wildcard << std::endl;
 // escape %
 
 	index = 0;
-	while ((index = wildcard.find('%',index)) != string::npos)
+	while ((index = wildcard.find('%',index)) != std::string::npos)
 	{
 		wildcard.insert(index, 1, '\\');
 		index = index+2;
@@ -92,7 +92,7 @@ string DataBase::replace_wildcard(const char *wildcard_c_str)
 // escape _
 
 	index = 0;
-	while ((index = wildcard.find('_',index)) != string::npos)
+	while ((index = wildcard.find('_',index)) != std::string::npos)
 	{
 		wildcard.insert(index, 1, '\\');
 		index = index+2;
@@ -102,7 +102,7 @@ string DataBase::replace_wildcard(const char *wildcard_c_str)
 // escape "
 
 	index = 0;
-	while ((index = wildcard.find('"',index)) != string::npos)
+	while ((index = wildcard.find('"',index)) != std::string::npos)
 	{
 		wildcard.insert(index, 1, '\\');
 		index = index+2;
@@ -112,7 +112,7 @@ string DataBase::replace_wildcard(const char *wildcard_c_str)
 // escape '
 
 	index = 0;
-	while ((index = wildcard.find('\'',index)) != string::npos)
+	while ((index = wildcard.find('\'',index)) != std::string::npos)
 	{
 		wildcard.insert(index, 1, '\\');
 		index = index+2;
@@ -120,7 +120,7 @@ string DataBase::replace_wildcard(const char *wildcard_c_str)
 
 // replace wildcard * with %
 
-	while ((index = wildcard.find('*')) != string::npos)
+	while ((index = wildcard.find('*')) != std::string::npos)
 	{
 		wildcard.replace(index, 1, 1, '%');
 	}
@@ -141,19 +141,19 @@ string DataBase::replace_wildcard(const char *wildcard_c_str)
 // out :		string - The result string .
 //
 //-----------------------------------------------------------------------------
-string DataBase::escape_string(const char *string_c_str)
+std::string DataBase::escape_string(const char *string_c_str)
 {
-	string escaped_string(string_c_str);
-	string::size_type index;
+	std::string escaped_string(string_c_str);
+	std::string::size_type index;
 
 	DEBUG_STREAM << "DataBase::escape_string() string in : " << escaped_string << std::endl;
 
 	//	escape bakckslash
 	index = 0;
-	while ((index = escaped_string.find('\\',index)) != string::npos)
+	while ((index = escaped_string.find('\\',index)) != std::string::npos)
 	{
 		//	Check if double backslash already treated by client
-		string	s = escaped_string.substr(index+1);
+		std::string	s = escaped_string.substr(index+1);
 
 			//	Check if another escape sequence treated by client
 		if (s.find('\"')==0 || s.find('\'')==0)
@@ -167,7 +167,7 @@ string DataBase::escape_string(const char *string_c_str)
 
 	//	escape "
 	index = 0;
-	while ((index = escaped_string.find('"',index)) != string::npos)
+	while ((index = escaped_string.find('"',index)) != std::string::npos)
 	{
 		if (index==0)	//	Cannot have '\' at -1 !
 		{
@@ -177,7 +177,7 @@ string DataBase::escape_string(const char *string_c_str)
 		else
 		{
 			//	Check if double quotes already treated by client
-			string	s = escaped_string.substr(index-1);
+			std::string	s = escaped_string.substr(index-1);
 			if (s.find('\\')==0)
 				index++;
 			else
@@ -191,7 +191,7 @@ string DataBase::escape_string(const char *string_c_str)
 
 	//	escape '
 	index = 0;
-	while ((index = escaped_string.find('\'',index)) != string::npos)
+	while ((index = escaped_string.find('\'',index)) != std::string::npos)
 	{
 		if (index==0)	//	Cannot have '\' at -1 !
 		{
@@ -201,7 +201,7 @@ string DataBase::escape_string(const char *string_c_str)
 		else
 		{
 			//	Check if simple quotes already treated by client
-			string	s = escaped_string.substr(index-1);
+			std::string	s = escaped_string.substr(index-1);
 			if (s.find('\\')==0)
 				index++;
 			else
@@ -218,7 +218,7 @@ string DataBase::escape_string(const char *string_c_str)
 
 //+----------------------------------------------------------------------------
 //
-// method : 		DataBase::device_name_to_dfm(string &device_name,
+// method : 		DataBase::device_name_to_dfm(std::string &device_name,
 //			          char **domain, char **family, char **member)
 //
 // description : 	utility function to return domain, family and member
@@ -231,9 +231,9 @@ string DataBase::escape_string(const char *string_c_str)
 // out :		bool - true or false
 //
 //-----------------------------------------------------------------------------
-bool DataBase::device_name_to_dfm(string &devname, char domain[], char family[], char member[])
+bool DataBase::device_name_to_dfm(std::string &devname, char domain[], char family[], char member[])
 {
-	string::size_type index, index2;
+	std::string::size_type index, index2;
 
 	DEBUG_STREAM << "DataBase::device_name_to_dfm() device name in " << devname << std::endl;
 
@@ -256,7 +256,7 @@ bool DataBase::device_name_to_dfm(string &devname, char domain[], char family[],
 
 //+----------------------------------------------------------------------------
 //
-// method : 		DataBase::check_device_name(string *device_name)
+// method : 		DataBase::check_device_name(std::string *device_name)
 //
 // description : 	utility function to check whether device name conforms
 //			to the TANGO naming convention of
@@ -268,17 +268,17 @@ bool DataBase::device_name_to_dfm(string &devname, char domain[], char family[],
 // out :		bool - true or false
 //
 //-----------------------------------------------------------------------------
-bool DataBase::check_device_name(string &device_name_str)
+bool DataBase::check_device_name(std::string &device_name_str)
 {
-	string devname(device_name_str);
-	string::size_type index, index2;
+	std::string devname(device_name_str);
+	std::string::size_type index, index2;
 
 	DEBUG_STREAM << "DataBase::check_device_name(): device_name in " << devname << std::endl;
 
 // check there are no special characters which could be interpreted
 // as wildcards or which are otherwise excluded
 
-	if (devname.find('*') != string::npos) return false;
+	if (devname.find('*') != std::string::npos) return false;
 
 // check protocol - "tango:" | "taco:"
 
@@ -299,7 +299,7 @@ bool DataBase::check_device_name(string &device_name_str)
 	if (devname.substr(0,2) == "//")
 	{
 		index = devname.find('/',(string::size_type)2);
-		if (index == 0 || index == string::npos)
+		if (index == 0 || index == std::string::npos)
 		{
 			return false;
 
@@ -312,7 +312,7 @@ bool DataBase::check_device_name(string &device_name_str)
 	index = devname.find('/');
 	index2 = devname.find('/',index+1);
 
-	if (index == 0 || index == string::npos || index2 == string::npos ||
+	if (index == 0 || index == std::string::npos || index2 == std::string::npos ||
 	    index2-index <= 0 || devname.length() - index2 <= 0)
 	{
 		return false;
@@ -445,7 +445,7 @@ Tango::DevULong64 DataBase::get_id(const char *name,int con_nb)
 
     sql_query.str("");
     sql_query << "UPDATE " << name << "_history_id SET id=LAST_INSERT_ID(id+1)";
-	string tmp_str = sql_query.str();
+	std::string tmp_str = sql_query.str();
 
 	if (mysql_real_query(conn_pool[con_nb].db, tmp_str.c_str(),tmp_str.length()) != 0)
 	{
@@ -489,7 +489,7 @@ Tango::DevULong64 DataBase::get_id(const char *name,int con_nb)
 // description : 	Execute a SQL query , ignore the result.
 //
 //-----------------------------------------------------------------------------
-void DataBase::simple_query(string sql_query,const char *method,int con_nb)
+void DataBase::simple_query(std::string sql_query,const char *method,int con_nb)
 {
 
 //
@@ -542,7 +542,7 @@ void DataBase::simple_query(string sql_query,const char *method,int con_nb)
 // description : 	Execute a SQL query and return the result.
 //
 //-----------------------------------------------------------------------------
-MYSQL_RES *DataBase::query(string sql_query,const char *method,int con_nb)
+MYSQL_RES *DataBase::query(std::string sql_query,const char *method,int con_nb)
 {
 	MYSQL_RES *result;
 
@@ -835,16 +835,16 @@ void DataBase::create_connection_pool(const char *mysql_user,
 	}
 
 	const char *host;
-	string my_host;
-	string ho,port;
+	std::string my_host;
+	std::string ho,port;
 	unsigned int port_num = 0;
 
 	if (mysql_host != NULL)
 	{
 		my_host = mysql_host;
 		WARN_STREAM << "DataBase::create_connection_pool(): mysql host = " << mysql_host << std::endl;
-		string::size_type pos = my_host.find(':');
-		if (pos != string::npos)
+		std::string::size_type pos = my_host.find(':');
+		if (pos != std::string::npos)
 		{
 			ho = my_host.substr(0,pos);
 			pos++;
@@ -944,7 +944,7 @@ void DataBase::create_connection_pool(const char *mysql_user,
  */
 //+------------------------------------------------------------------
 
-bool DataBase::host_port_from_ior(const char *iorstr,string &h_p)
+bool DataBase::host_port_from_ior(const char *iorstr,std::string &h_p)
 {
 	size_t s = (iorstr ? strlen(iorstr) : 0);
 
@@ -1032,8 +1032,8 @@ bool DataBase::host_port_from_ior(const char *iorstr,string &h_p)
 				ho = pBody.address.host.in();
 				bool host_is_name = false;
 
-				string::size_type pos = ho.find('.');
-				if (pos == string::npos)
+				std::string::size_type pos = ho.find('.');
+				if (pos == std::string::npos)
 					host_is_name = true;
 				else
 				{
@@ -1076,7 +1076,7 @@ bool DataBase::host_port_from_ior(const char *iorstr,string &h_p)
 				}
 				else
 				{
-					if (pos == string::npos)
+					if (pos == std::string::npos)
 					{
 						Tango::DeviceProxy::get_fqdn(ho);
 					}

--- a/DataBaseUtils.cpp
+++ b/DataBaseUtils.cpp
@@ -79,7 +79,7 @@ string DataBase::replace_wildcard(const char *wildcard_c_str)
 	string wildcard(wildcard_c_str);
 	string::size_type index;
 
-	DEBUG_STREAM << "DataBase::replace_wildcard() wildcard in " << wildcard << endl;
+	DEBUG_STREAM << "DataBase::replace_wildcard() wildcard in " << wildcard << std::endl;
 // escape %
 
 	index = 0;
@@ -125,7 +125,7 @@ string DataBase::replace_wildcard(const char *wildcard_c_str)
 		wildcard.replace(index, 1, 1, '%');
 	}
 
-	DEBUG_STREAM << "DataBase::replace_wildcard() wildcard out " << wildcard << endl;
+	DEBUG_STREAM << "DataBase::replace_wildcard() wildcard out " << wildcard << std::endl;
 	return wildcard;
 }
 
@@ -146,7 +146,7 @@ string DataBase::escape_string(const char *string_c_str)
 	string escaped_string(string_c_str);
 	string::size_type index;
 
-	DEBUG_STREAM << "DataBase::escape_string() string in : " << escaped_string << endl;
+	DEBUG_STREAM << "DataBase::escape_string() string in : " << escaped_string << std::endl;
 
 	//	escape bakckslash
 	index = 0;
@@ -212,7 +212,7 @@ string DataBase::escape_string(const char *string_c_str)
 		}
 	}
 
-	DEBUG_STREAM << "DataBase::escaped_string() wildcard out : " << escaped_string << endl;
+	DEBUG_STREAM << "DataBase::escaped_string() wildcard out : " << escaped_string << std::endl;
 	return escaped_string;
 }
 
@@ -235,7 +235,7 @@ bool DataBase::device_name_to_dfm(string &devname, char domain[], char family[],
 {
 	string::size_type index, index2;
 
-	DEBUG_STREAM << "DataBase::device_name_to_dfm() device name in " << devname << endl;
+	DEBUG_STREAM << "DataBase::device_name_to_dfm() device name in " << devname << std::endl;
 
 	index = devname.find('/');
 	index2 = devname.find('/', index+1);
@@ -249,7 +249,7 @@ bool DataBase::device_name_to_dfm(string &devname, char domain[], char family[],
 	(devname.substr(index2+1)).copy(member,devname.length()-index2);
 	member[devname.length()-index2-1] = '\0';
 
-	DEBUG_STREAM << "DataBase::device_name_to_dfm() domain/family/member out " << domain << "/" << family << "/" << member << endl;
+	DEBUG_STREAM << "DataBase::device_name_to_dfm() domain/family/member out " << domain << "/" << family << "/" << member << std::endl;
 
 	return true;
 }
@@ -273,7 +273,7 @@ bool DataBase::check_device_name(string &device_name_str)
 	string devname(device_name_str);
 	string::size_type index, index2;
 
-	DEBUG_STREAM << "DataBase::check_device_name(): device_name in " << devname << endl;
+	DEBUG_STREAM << "DataBase::check_device_name(): device_name in " << devname << std::endl;
 
 // check there are no special characters which could be interpreted
 // as wildcards or which are otherwise excluded
@@ -320,7 +320,7 @@ bool DataBase::check_device_name(string &device_name_str)
 
 	device_name_str = devname;
 
-	DEBUG_STREAM << "DataBase::check_device_name(): device_name out " << device_name_str << endl;
+	DEBUG_STREAM << "DataBase::check_device_name(): device_name out " << device_name_str << std::endl;
 
 	return true;
 }
@@ -406,11 +406,11 @@ void DataBase::check_history_tables()
 	TangoSys_MemStream	sql_query_stream;
 	MYSQL_RES *result;
 
-	INFO_STREAM << "DataBase::check_history_tables(): entering" << endl;
+	INFO_STREAM << "DataBase::check_history_tables(): entering" << std::endl;
 
 	sql_query_stream.str("");
 	sql_query_stream << "SELECT count(*) FROM property_device_hist";
-	DEBUG_STREAM << "DataBase::check_history_tables(): sql_query " << sql_query_stream.str() << endl;
+	DEBUG_STREAM << "DataBase::check_history_tables(): sql_query " << sql_query_stream.str() << std::endl;
 	result = query(sql_query_stream.str(),"check_history_tables()");
 	mysql_free_result(result);
 }
@@ -451,11 +451,11 @@ Tango::DevULong64 DataBase::get_id(const char *name,int con_nb)
 	{
 		TangoSys_OMemStream o;
 
-		WARN_STREAM << "DataBase::get_id() failed to query TANGO database:" << endl;
-		WARN_STREAM << "  query = " << tmp_str << endl;
-		WARN_STREAM << " (SQL error=" << mysql_error(conn_pool[con_nb].db) << ")" << endl;
+		WARN_STREAM << "DataBase::get_id() failed to query TANGO database:" << std::endl;
+		WARN_STREAM << "  query = " << tmp_str << std::endl;
+		WARN_STREAM << " (SQL error=" << mysql_error(conn_pool[con_nb].db) << ")" << std::endl;
 
-		o << "Failed to query TANGO database (error=" << mysql_error(conn_pool[con_nb].db) << ")" << ends;
+		o << "Failed to query TANGO database (error=" << mysql_error(conn_pool[con_nb].db) << ")" << std::ends;
 
 		if (need_release == true)
 			release_connection(con_nb);
@@ -505,7 +505,7 @@ void DataBase::simple_query(string sql_query,const char *method,int con_nb)
 		need_release = true;
 	}
 
-	DEBUG_STREAM << "Using MySQL connection with semaphore " << con_nb << endl;
+	DEBUG_STREAM << "Using MySQL connection with semaphore " << con_nb << std::endl;
 
 //
 // Call MySQL
@@ -516,13 +516,13 @@ void DataBase::simple_query(string sql_query,const char *method,int con_nb)
 		TangoSys_OMemStream o;
 		TangoSys_OMemStream o2;
 
-		WARN_STREAM << "DataBase::" << method << " failed to query TANGO database:" << endl;
-		WARN_STREAM << "  query = " << sql_query << endl;
-		WARN_STREAM << " (SQL error=" << mysql_error(conn_pool[con_nb].db) << ")" << endl;
+		WARN_STREAM << "DataBase::" << method << " failed to query TANGO database:" << std::endl;
+		WARN_STREAM << "  query = " << sql_query << std::endl;
+		WARN_STREAM << " (SQL error=" << mysql_error(conn_pool[con_nb].db) << ")" << std::endl;
 
 		o << "Failed to query TANGO database (error=" << mysql_error(conn_pool[con_nb].db) << ")";
-		o << "\n.The query was: " << sql_query << ends;
-		o2 << "DataBase::" << method << ends;
+		o << "\n.The query was: " << sql_query << std::ends;
+		o2 << "DataBase::" << method << std::ends;
 
 		if (need_release == true)
 			release_connection(con_nb);
@@ -559,7 +559,7 @@ MYSQL_RES *DataBase::query(string sql_query,const char *method,int con_nb)
 		need_release = true;
 	}
 
-	DEBUG_STREAM << "Using MySQL connection with semaphore " << con_nb << endl;
+	DEBUG_STREAM << "Using MySQL connection with semaphore " << con_nb << std::endl;
 
 //
 // Call MySQL
@@ -570,13 +570,13 @@ MYSQL_RES *DataBase::query(string sql_query,const char *method,int con_nb)
 		TangoSys_OMemStream o;
 		TangoSys_OMemStream o2;
 
-		WARN_STREAM << "DataBase::" << method << " failed to query TANGO database:" << endl;
-		WARN_STREAM << "  query = " << sql_query << endl;
-		WARN_STREAM << " (SQL error=" << mysql_error(conn_pool[con_nb].db) << ")" << endl;
+		WARN_STREAM << "DataBase::" << method << " failed to query TANGO database:" << std::endl;
+		WARN_STREAM << "  query = " << sql_query << std::endl;
+		WARN_STREAM << " (SQL error=" << mysql_error(conn_pool[con_nb].db) << ")" << std::endl;
 
 		o << "Failed to query TANGO database (error=" << mysql_error(conn_pool[con_nb].db) << ")";
-		o << "\nThe query was: " << sql_query << ends;
-		o2 << "DataBase::" << method << ends;
+		o << "\nThe query was: " << sql_query << std::ends;
+		o2 << "DataBase::" << method << std::ends;
 
 		if (need_release == true)
 			release_connection(con_nb);
@@ -589,7 +589,7 @@ MYSQL_RES *DataBase::query(string sql_query,const char *method,int con_nb)
 		TangoSys_OMemStream o;
 		TangoSys_OMemStream o2;
 
-		WARN_STREAM << "DataBase:: " << method << " : mysql_store_result() failed  (error=" << mysql_error(conn_pool[con_nb].db) << ")" << endl;
+		WARN_STREAM << "DataBase:: " << method << " : mysql_store_result() failed  (error=" << mysql_error(conn_pool[con_nb].db) << ")" << std::endl;
 
 		o << "mysql_store_result() failed (error=" << mysql_error(conn_pool[con_nb].db) << ")";
 		o2 << "DataBase::" << method;
@@ -636,7 +636,7 @@ int DataBase::get_connection()
 					last_sem_wait = 0;
 			}
 			loop = sem_to_wait;
-			WARN_STREAM << "Waiting for one free MySQL connection on semaphore " << loop << endl;
+			WARN_STREAM << "Waiting for one free MySQL connection on semaphore " << loop << std::endl;
 			conn_pool[loop].the_sema.wait();
 			break;
 		}
@@ -696,7 +696,7 @@ void DataBase::purge_att_property(const char *table,const char *field,const char
   MYSQL_RES *result;
   MYSQL_ROW row2;
 
-  //cout << "purge_att_property(" << object << "," << attribute << "," << name << ")" << endl;
+  //cout << "purge_att_property(" << object << "," << attribute << "," << name << ")" << std::endl;
 
   sql_query.str("");
   sql_query << "SELECT DISTINCT id,date FROM " << table
@@ -733,7 +733,7 @@ void DataBase::purge_pipe_property(const char *table,const char *field,const cha
   MYSQL_RES *result;
   MYSQL_ROW row2;
 
-  //cout << "purge_pipe_property(" << object << "," << pipe << "," << name << ")" << endl;
+  //cout << "purge_pipe_property(" << object << "," << pipe << "," << name << ")" << std::endl;
 
   sql_query.str("");
   sql_query << "SELECT DISTINCT id,date FROM " << table
@@ -784,11 +784,11 @@ void DataBase::base_connect(int loop)
 		my_bool my_auto_reconnect=1;
 		if (mysql_options(conn_pool[loop].db,MYSQL_OPT_RECONNECT,&my_auto_reconnect) !=0)
 		{
-			ERROR_STREAM << "DataBase: error setting mysql auto reconnection: " << mysql_error(conn_pool[loop].db) << endl;
+			ERROR_STREAM << "DataBase: error setting mysql auto reconnection: " << mysql_error(conn_pool[loop].db) << std::endl;
 		}
 		else
 		{
-			WARN_STREAM << "DataBase: set mysql auto reconnect to true" << endl;
+			WARN_STREAM << "DataBase: set mysql auto reconnect to true" << std::endl;
 		}
 	}
 #endif
@@ -831,7 +831,7 @@ void DataBase::create_connection_pool(const char *mysql_user,
 	if (mysql_user != NULL && mysql_password != NULL)
 	{
 		WARN_STREAM << "DataBase::create_connection_pool(): mysql database user =  " << mysql_user
-	           	 << " , password = " << mysql_password << endl;
+	           	 << " , password = " << mysql_password << std::endl;
 	}
 
 	const char *host;
@@ -842,7 +842,7 @@ void DataBase::create_connection_pool(const char *mysql_user,
 	if (mysql_host != NULL)
 	{
 		my_host = mysql_host;
-		WARN_STREAM << "DataBase::create_connection_pool(): mysql host = " << mysql_host << endl;
+		WARN_STREAM << "DataBase::create_connection_pool(): mysql host = " << mysql_host << std::endl;
 		string::size_type pos = my_host.find(':');
 		if (pos != string::npos)
 		{
@@ -857,7 +857,7 @@ void DataBase::create_connection_pool(const char *mysql_user,
 		}
 		else
 			host = my_host.c_str();
-		WARN_STREAM << "DataBase::create_connection_pool(): mysql host = " << host << ", port = " << port_num << endl;
+		WARN_STREAM << "DataBase::create_connection_pool(): mysql host = " << host << ", port = " << port_num << std::endl;
 	}
 	else
 		host = NULL;
@@ -877,7 +877,7 @@ void DataBase::create_connection_pool(const char *mysql_user,
 //
 
 
-		WARN_STREAM << "Going to connect to MySQL for conn. " << loop << endl;
+		WARN_STREAM << "Going to connect to MySQL for conn. " << loop << std::endl;
 		if (!mysql_real_connect(conn_pool[loop].db, host, mysql_user, mysql_password, database, port_num, NULL, CLIENT_MULTI_STATEMENTS | CLIENT_FOUND_ROWS))
 		{
 			if (loop == 0)
@@ -887,23 +887,23 @@ void DataBase::create_connection_pool(const char *mysql_user,
 				{
 					sleep(1);
 					int db_err = mysql_errno(conn_pool[loop].db);
-					WARN_STREAM << "Connection to MySQL failed with error " << db_err << endl;
+					WARN_STREAM << "Connection to MySQL failed with error " << db_err << std::endl;
 					if (db_err == CR_CONNECTION_ERROR || db_err == CR_CONN_HOST_ERROR)
 					{
 						mysql_close(conn_pool[loop].db);
 						conn_pool[loop].db = NULL;
 						base_connect(loop);
 					}
-					WARN_STREAM << "Going to retry to connect to MySQL for connection " << loop << endl;
+					WARN_STREAM << "Going to retry to connect to MySQL for connection " << loop << std::endl;
 					if (!mysql_real_connect(conn_pool[loop].db, host, mysql_user, mysql_password, database, port_num, NULL, CLIENT_MULTI_STATEMENTS | CLIENT_FOUND_ROWS))
 					{
-						WARN_STREAM << "Connection to MySQL (re-try) failed with error " << mysql_errno(conn_pool[loop].db) << endl;
+						WARN_STREAM << "Connection to MySQL (re-try) failed with error " << mysql_errno(conn_pool[loop].db) << std::endl;
 						retry--;
 						if (retry == 0)
 						{
-							WARN_STREAM << "Throw exception because no MySQL connection possible after 5 re-tries" << endl;
+							WARN_STREAM << "Throw exception because no MySQL connection possible after 5 re-tries" << std::endl;
 							TangoSys_MemStream out_stream;
-							out_stream << "Failed to connect to TANGO database (error = " << mysql_error(conn_pool[loop].db) << ")" << ends;
+							out_stream << "Failed to connect to TANGO database (error = " << mysql_error(conn_pool[loop].db) << ")" << std::ends;
 
 							Tango::Except::throw_exception((const char *)"CANNOT_CONNECT_MYSQL",
 												out_stream.str(),
@@ -912,16 +912,16 @@ void DataBase::create_connection_pool(const char *mysql_user,
 					}
 					else
 					{
-						WARN_STREAM << "MySQL connection succeed after retry" << endl;
+						WARN_STREAM << "MySQL connection succeed after retry" << std::endl;
 						retry = 0;
 					}
 				}
 			}
 			else
 			{
-				WARN_STREAM << "Failed to connect to MySQL for conn. " << loop << ". No re-try in this case" << endl;
+				WARN_STREAM << "Failed to connect to MySQL for conn. " << loop << ". No re-try in this case" << std::endl;
 				TangoSys_MemStream out_stream;
-				out_stream << "Failed to connect to TANGO database (error = " << mysql_error(conn_pool[loop].db) << ")" << ends;
+				out_stream << "Failed to connect to TANGO database (error = " << mysql_error(conn_pool[loop].db) << ")" << std::ends;
 
 				Tango::Except::throw_exception((const char *)"CANNOT_CONNECT_MYSQL",
 												out_stream.str(),

--- a/main.cpp
+++ b/main.cpp
@@ -217,7 +217,7 @@ int main(int argc,char *argv[])
 		cout << "Ready to accept request" << std::endl;
 		(tango_util->get_orb())->run();
 	}
-	catch (bad_alloc)
+	catch (std::bad_alloc)
 	{
 		cout << "Can't allocate memory to store device object !!!" << std::endl;
 		cout << "Exiting" << std::endl;

--- a/main.cpp
+++ b/main.cpp
@@ -64,7 +64,7 @@ int DataBase_ns::DataBase::conn_pool_size;
 int main(int argc,char *argv[])
 {
 
-	cout << "main(): arrived " << endl;
+	cout << "main(): arrived " << std::endl;
 
 	Tango::Util *tango_util;
 	Tango::Util::_UseDb = false; // suppress database use
@@ -87,12 +87,12 @@ int main(int argc,char *argv[])
 	}
 	if( found ) {
 	  if(i>=argc-1) {
-	    cout << "Invalid flimit parameter." << endl;
+	    cout << "Invalid flimit parameter." << std::endl;
 	    return -1;
 	  }
 	  int flimit = atoi(argv[i+1]);
 	  if(flimit==0) {
-	    cout << "Invalid flimit parameter." << endl;
+	    cout << "Invalid flimit parameter." << std::endl;
 	    return -1;
 	  }
 	  limit.rlim_cur = flimit;
@@ -101,11 +101,11 @@ int main(int argc,char *argv[])
 
 	// Apply the max open file limit
 	if( setrlimit(RLIMIT_NOFILE,&limit) != 0 ) {
-	  cout << "setrlimit(RLIMIT_NOFILE," << (int)limit.rlim_cur << ") failed." << endl;
+	  cout << "setrlimit(RLIMIT_NOFILE," << (int)limit.rlim_cur << ") failed." << std::endl;
 	  if(errno==EPERM) {
-	    cout << "You may need to increase maximum number of opened file system limit." << endl;
+	    cout << "You may need to increase maximum number of opened file system limit." << std::endl;
 	  } else {
-	    cout << "setrlimit() failed with error code : " << (int)errno << endl;
+	    cout << "setrlimit() failed with error code : " << (int)errno << std::endl;
 	  }
 	  return -1;
 	}
@@ -125,12 +125,12 @@ int main(int argc,char *argv[])
 	}
 	if( found_conn ) {
 	  if(j>=argc-1) {
-	    cout << "Invalid poolSize parameter." << endl;
+	    cout << "Invalid poolSize parameter." << std::endl;
 	    return -1;
 	  }
 	  conn_size = atoi(argv[j+1]);
 	  if(conn_size<=0) {
-	    cout << "Invalid poolSize parameter." << endl;
+	    cout << "Invalid poolSize parameter." << std::endl;
 	    return -1;
 	  }
 	}
@@ -142,14 +142,14 @@ int main(int argc,char *argv[])
 //
 // Initialise the device server
 //
-		cout1 << "main(): calling  Tango::Util::Init(argc,argv)" << endl;
+		cout1 << "main(): calling  Tango::Util::Init(argc,argv)" << std::endl;
 		tango_util = Tango::Util::init(argc,argv);
 
 // construct database name
 
 		DataBase_ns::DataBase::db_name = "sys/database/";
 		DataBase_ns::DataBase::db_name.append(argv[1]);
-		cout1 << "main(): create DataBase " << DataBase_ns::DataBase::db_name << endl;
+		cout1 << "main(): create DataBase " << DataBase_ns::DataBase::db_name << std::endl;
 
 //
 // Create and install interceptors
@@ -168,7 +168,7 @@ int main(int argc,char *argv[])
 // Create the device server singleton which will create everything
 //
 
-		cout1 << "main(): calling  tango_util->server_init()" << endl;
+		cout1 << "main(): calling  tango_util->server_init()" << std::endl;
 		tango_util->server_init();
 
 //
@@ -183,7 +183,7 @@ int main(int argc,char *argv[])
 //
 // export database as named servant
 //
-		cout << "main(): export DataBase as named servant (name=database)" << endl;
+		cout << "main(): export DataBase as named servant (name=database)" << std::endl;
 		export_parms->length(5);
 
 // export dserver object to TANGO database
@@ -214,19 +214,19 @@ int main(int argc,char *argv[])
 // Run the endless loop
 //
 
-		cout << "Ready to accept request" << endl;
+		cout << "Ready to accept request" << std::endl;
 		(tango_util->get_orb())->run();
 	}
 	catch (bad_alloc)
 	{
-		cout << "Can't allocate memory to store device object !!!" << endl;
-		cout << "Exiting" << endl;
+		cout << "Can't allocate memory to store device object !!!" << std::endl;
+		cout << "Exiting" << std::endl;
 	}
 	catch (CORBA::Exception &e)
 	{
-		cout << "Received a CORBA::Exception" << endl;
+		cout << "Received a CORBA::Exception" << std::endl;
 		Tango::Except::print_exception(e);
-		cout << "Exiting" << endl;
+		cout << "Exiting" << std::endl;
 	}
 
 	return(0);

--- a/update_starter.cpp
+++ b/update_starter.cpp
@@ -43,28 +43,28 @@ namespace DataBase_ns
 {
 //=============================================================================
 //=============================================================================
-UpdStarterData::UpdStarterData(string domain)
+UpdStarterData::UpdStarterData(std::string domain)
 {
     starter_header = domain;
 	starter_header += STARTER_DEVNAME_FAMILY;
 }
 //=============================================================================
 //=============================================================================
-vector<string> UpdStarterData::get_starter_devname()
+vector<std::string> UpdStarterData::get_starter_devname()
 {
 	omni_mutex_lock sync(*this);
 	return starter_devnames;
 }
 //=============================================================================
 //=============================================================================
-string UpdStarterData::get_starter_header()
+std::string UpdStarterData::get_starter_header()
 {
 	omni_mutex_lock sync(*this);
 	return starter_header;
 }
 //=============================================================================
 //=============================================================================
-void UpdStarterData::send_starter_cmd(vector<string> hostnames)
+void UpdStarterData::send_starter_cmd(vector<std::string> hostnames)
 {
 	omni_mutex_lock sync(*this);
 
@@ -72,7 +72,7 @@ void UpdStarterData::send_starter_cmd(vector<string> hostnames)
 	starter_devnames.clear();
 	for (unsigned int i=0 ; i<hostnames.size() ; i++)
 	{
-		string	devname(starter_header);
+		std::string	devname(starter_header);
 		devname += hostnames[i];
 		starter_devnames.push_back(devname);
 	}
@@ -95,16 +95,16 @@ void *UpdateStarter::run_undetached(TANGO_UNUSED(void *ptr))
 	while(true)
 	{
 		//	Get the starter device name
-		vector<string>	devnames = shared->get_starter_devname();
-        string starter_header = shared->get_starter_header();
+		vector<std::string>	devnames = shared->get_starter_devname();
+        std::string starter_header = shared->get_starter_header();
 		for (unsigned int i=0 ; i<devnames.size() ; i++)
 		{
 			//	Verify if devname has been set
 			if (devnames[i].find(starter_header)==0)
 			{
 				//	Remove the Fully Qualify Domain Name of host for device name
-				string::size_type	pos = devnames[i].find('.');
-				if (pos != string::npos)
+				std::string::size_type	pos = devnames[i].find('.');
+				if (pos != std::string::npos)
 					 devnames[i] = devnames[i].substr(0, pos);
 				//cout << "Fire info to " << devnames[i] << std::endl;
 

--- a/update_starter.cpp
+++ b/update_starter.cpp
@@ -106,21 +106,21 @@ void *UpdateStarter::run_undetached(TANGO_UNUSED(void *ptr))
 				string::size_type	pos = devnames[i].find('.');
 				if (pos != string::npos)
 					 devnames[i] = devnames[i].substr(0, pos);
-				//cout << "Fire info to " << devnames[i] << endl;
+				//cout << "Fire info to " << devnames[i] << std::endl;
 
 				Tango::DeviceProxy	*dev = NULL;
 				try
 				{
 					//	Build connection and send command
 					dev = new Tango::DeviceProxy(devnames[i]);
-					cout << devnames[i] << " imported" << endl;
+					cout << devnames[i] << " imported" << std::endl;
 					dev->command_inout("UpdateServersInfo");
-					cout << "dev->command_inout(UpdateServersInfo) sent to " << devnames[i] << endl;
+					cout << "dev->command_inout(UpdateServersInfo) sent to " << devnames[i] << std::endl;
 				}
 				catch(Tango::DevFailed &e)
 				{
 					//Tango::Except::print_exception(e);
-					cout << e.errors[0].desc << endl;
+					cout << e.errors[0].desc << std::endl;
 				}
 				delete dev;
 			}
@@ -130,7 +130,7 @@ void *UpdateStarter::run_undetached(TANGO_UNUSED(void *ptr))
 			omni_mutex_lock sync(*shared);
 			shared->wait();
 		}
-		cout2 << "Thread update_starter awaken !" << endl;
+		cout2 << "Thread update_starter awaken !" << std::endl;
 		
 	}
 	return NULL;

--- a/update_starter.cpp
+++ b/update_starter.cpp
@@ -50,7 +50,7 @@ UpdStarterData::UpdStarterData(std::string domain)
 }
 //=============================================================================
 //=============================================================================
-vector<std::string> UpdStarterData::get_starter_devname()
+std::vector<std::string> UpdStarterData::get_starter_devname()
 {
 	omni_mutex_lock sync(*this);
 	return starter_devnames;
@@ -64,7 +64,7 @@ std::string UpdStarterData::get_starter_header()
 }
 //=============================================================================
 //=============================================================================
-void UpdStarterData::send_starter_cmd(vector<std::string> hostnames)
+void UpdStarterData::send_starter_cmd(std::vector<std::string> hostnames)
 {
 	omni_mutex_lock sync(*this);
 
@@ -95,8 +95,8 @@ void *UpdateStarter::run_undetached(TANGO_UNUSED(void *ptr))
 	while(true)
 	{
 		//	Get the starter device name
-		vector<std::string>	devnames = shared->get_starter_devname();
-        std::string starter_header = shared->get_starter_header();
+		std::vector<std::string>	devnames = shared->get_starter_devname();
+		std::string starter_header = shared->get_starter_header();
 		for (unsigned int i=0 ; i<devnames.size() ; i++)
 		{
 			//	Verify if devname has been set

--- a/update_starter.h
+++ b/update_starter.h
@@ -54,19 +54,19 @@ namespace DataBase_ns {
 class UpdStarterData: public Tango::TangoMonitor
 {
 private:
-	vector<string>	starter_devnames;
-    string starter_header;
+	vector<std::string>	starter_devnames;
+    std::string starter_header;
 public:
-	UpdStarterData(string starter_domain);
+	UpdStarterData(std::string starter_domain);
 /**
  *	Get the host name to send cmd
  */
-vector<string> get_starter_devname();
-string get_starter_header();
+vector<std::string> get_starter_devname();
+std::string get_starter_header();
 /**
  *	Set the host name to send cmd
  */
-void send_starter_cmd(vector<string> hostnames);
+void send_starter_cmd(vector<std::string> hostnames);
 };
 //=========================================================
 /**

--- a/update_starter.h
+++ b/update_starter.h
@@ -54,19 +54,19 @@ namespace DataBase_ns {
 class UpdStarterData: public Tango::TangoMonitor
 {
 private:
-	vector<std::string>	starter_devnames;
+	std::vector<std::string>	starter_devnames;
     std::string starter_header;
 public:
 	UpdStarterData(std::string starter_domain);
 /**
  *	Get the host name to send cmd
  */
-vector<std::string> get_starter_devname();
+std::vector<std::string> get_starter_devname();
 std::string get_starter_header();
 /**
  *	Set the host name to send cmd
  */
-void send_starter_cmd(vector<std::string> hostnames);
+void send_starter_cmd(std::vector<std::string> hostnames);
 };
 //=========================================================
 /**


### PR DESCRIPTION
As for https://github.com/tango-controls/TangoTest/pull/16:
- I regenerated the files with Pogo 9.7.x (2a87701)
- I added the `std` prefix to `endl`, `stringstream`, `string`, `vector`, `map` and `bad_alloc` 